### PR TITLE
fix(dashboard-init): restore re-login functionality

### DIFF
--- a/src/app/routes/dashboard/dashboard.component.ts
+++ b/src/app/routes/dashboard/dashboard.component.ts
@@ -6,7 +6,7 @@ import { ToastrService } from 'ngx-toastr';
 import { FormGroup, FormBuilder, FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { startWith, map, switchMap } from 'rxjs/operators';
-import { ENSNamespaceTypes } from 'iam-client-lib';
+import { ENSNamespaceTypes, WalletProvider } from 'iam-client-lib';
 
 @Component({
   selector: 'app-dashboard',
@@ -65,13 +65,13 @@ export class DashboardComponent implements OnInit {
           // console.log('local > login');
 
           // Set metamask extension options if connecting with metamask extension
-          let useMetamaskExtension = undefined;
+          let walletProvider = WalletProvider.WalletConnect;
           if (window.localStorage.getItem('METAMASK_EXT_CONNECTED')) {
-            useMetamaskExtension = true;
+            walletProvider = WalletProvider.MetaMask;
           }
 
           // Proceed Login
-          await this.iamService.login(useMetamaskExtension);
+          await this.iamService.login(walletProvider);
           this.iamService.clearWaitSignatureTimer();
         }
 


### PR DESCRIPTION
Issue was that useMetamaskExtension param was removed so iam-client-lib was throwing exception when receiving receiving WalletProvider type that was not allowed.

Functionality may still not be ideal. Relogin on reload with metamask works. However, walletconnect/KM re-login likely does not. I don't believe it currently works on https://volta-switchboard.energyweb.org (master branch) either but I'm not certain. I'm not sure if the walletConnect library is checking for existing session information from local storage or if we would need to pass in an existing walletConnect session info into iam-client-lib and then re-establish the connection to the session based on that. Needs a bit more investigation on my part...