### PR TITLE
fix(SWTCH-942): assets for did without profile claim do not appear on the list.

### DIFF
--- a/src/app/routes/assets/asset-list/asset-list.component.ts
+++ b/src/app/routes/assets/asset-list/asset-list.component.ts
@@ -12,7 +12,7 @@ import { TransferOwnershipComponent } from '../../applications/transfer-ownershi
 import { ConfirmationDialogComponent } from '../../widgets/confirmation-dialog/confirmation-dialog.component';
 import { AssetOwnershipHistoryComponent } from '../asset-ownership-history/asset-ownership-history.component';
 import { EditAssetDialogComponent } from '../edit-asset-dialog/edit-asset-dialog.component';
-import { finalize, first, map, switchMap, tap } from 'rxjs/operators';
+import { filter, finalize, first, map, switchMap, tap } from 'rxjs/operators';
 import { forkJoin, from, Observable } from 'rxjs';
 import { VerificationMethodComponent } from '../verification-method/verification-method.component';
 import { mapClaimsProfile } from '../operators/map-claims-profile';
@@ -225,6 +225,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
 
     this.subscribeTo(dialogRef.afterClosed().pipe(
       first(),
+      filter(Boolean),
       tap(() => this.loadingService.show()),
       switchMap(() => this.assetListFactory())
     ));

--- a/src/app/routes/assets/asset-list/asset-list.component.ts
+++ b/src/app/routes/assets/asset-list/asset-list.component.ts
@@ -236,8 +236,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
     return forkJoin(
       from(
         this.iamService.iam.getUserClaims()).pipe(
-        mapClaimsProfile(),
-        map(claim => claim.profile && claim.profile),
+        mapClaimsProfile()
       ),
       this.loadAssetList(this.iamService.iam.getOwnedAssets())
     ).pipe(

--- a/src/app/routes/assets/asset-list/asset-list.component.ts
+++ b/src/app/routes/assets/asset-list/asset-list.component.ts
@@ -221,6 +221,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
       width: '600px',
       data,
       maxWidth: '100%',
+      disableClose: true
     });
 
     this.subscribeTo(dialogRef.afterClosed().pipe(

--- a/src/app/routes/assets/asset-list/asset-list.component.ts
+++ b/src/app/routes/assets/asset-list/asset-list.component.ts
@@ -12,9 +12,10 @@ import { TransferOwnershipComponent } from '../../applications/transfer-ownershi
 import { ConfirmationDialogComponent } from '../../widgets/confirmation-dialog/confirmation-dialog.component';
 import { AssetOwnershipHistoryComponent } from '../asset-ownership-history/asset-ownership-history.component';
 import { EditAssetDialogComponent } from '../edit-asset-dialog/edit-asset-dialog.component';
-import { finalize, first, flatMap, map, switchMap, tap } from 'rxjs/operators';
+import { finalize, first, map, switchMap, tap } from 'rxjs/operators';
 import { forkJoin, from, Observable } from 'rxjs';
 import { VerificationMethodComponent } from '../verification-method/verification-method.component';
+import { mapClaimsProfile } from '../operators/map-claims-profile';
 
 export const RESET_LIST = true;
 
@@ -233,7 +234,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
     return forkJoin(
       from(
         this.iamService.iam.getUserClaims()).pipe(
-        flatMap((claimsData) => claimsData.filter(claim => !!claim.profile)),
+        mapClaimsProfile(),
         map(claim => claim.profile && claim.profile),
       ),
       this.loadAssetList(this.iamService.iam.getOwnedAssets())

--- a/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
+++ b/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
@@ -45,7 +45,7 @@ export class EditAssetDialogComponent implements OnInit {
   }
 
   close() {
-    this.dialogRef.close();
+    this.dialogRef.close(false);
   }
 
   update() {
@@ -59,7 +59,7 @@ export class EditAssetDialogComponent implements OnInit {
       takeUntil(this.dialogRef.afterClosed())
     ).subscribe(() => {
       this.loadingService.hide();
-      this.close();
+      this.dialogRef.close(true);
     });
   }
 

--- a/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
+++ b/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
@@ -3,11 +3,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { FormBuilder, Validators } from '@angular/forms';
 import { IamService } from '../../../shared/services/iam.service';
 import { from } from 'rxjs';
-import { flatMap, map, takeUntil } from 'rxjs/operators';
-import { Asset } from 'iam-client-lib';
+import { map, takeUntil } from 'rxjs/operators';
+import { Asset, AssetProfile, ClaimData, Profile } from 'iam-client-lib';
 import { LoadingService } from '../../../shared/services/loading.service';
 import { CancelButton } from '../../../layout/loading/loading.component';
-import { AssetProfile, ClaimData, Profile } from 'iam-client-lib';
+import { mapClaimsProfile } from '../operators/map-claims-profile';
 
 const assetProfilesKey = 'assetProfiles';
 
@@ -35,7 +35,7 @@ export class EditAssetDialogComponent implements OnInit {
   ngOnInit(): void {
     this.loadingService.show();
     from(this.iamService.iam.getUserClaims()).pipe(
-      flatMap((data) => data.filter(claim => !!claim.profile)),
+      mapClaimsProfile(),
       map(claim => claim.profile && claim.profile)
     ).subscribe((profiles: any) => {
       this.loadingService.hide();
@@ -68,7 +68,7 @@ export class EditAssetDialogComponent implements OnInit {
       profile: {
         ...this.profile,
         assetProfiles: {
-          ...this.profile.assetProfiles,
+          ...(this.profile && this.profile.assetProfiles),
           [this.data.id]: {
             ...this.form.getRawValue()
           }
@@ -78,7 +78,7 @@ export class EditAssetDialogComponent implements OnInit {
   }
 
   private updateForm(profile) {
-    const assetProfile: AssetProfile = profile[assetProfilesKey] && profile[assetProfilesKey][this.data.id];
+    const assetProfile: AssetProfile = profile && profile[assetProfilesKey] && profile[assetProfilesKey][this.data.id];
 
     if (!assetProfile) {
       return;

--- a/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
+++ b/src/app/routes/assets/edit-asset-dialog/edit-asset-dialog.component.ts
@@ -35,12 +35,11 @@ export class EditAssetDialogComponent implements OnInit {
   ngOnInit(): void {
     this.loadingService.show();
     from(this.iamService.iam.getUserClaims()).pipe(
-      mapClaimsProfile(),
-      map(claim => claim.profile && claim.profile)
-    ).subscribe((profiles: any) => {
+      mapClaimsProfile()
+    ).subscribe((profile: any) => {
       this.loadingService.hide();
-      this.profile = profiles;
-      this.updateForm(profiles);
+      this.profile = profile;
+      this.updateForm(profile);
     });
   }
 

--- a/src/app/routes/assets/operators/map-claims-profile.ts
+++ b/src/app/routes/assets/operators/map-claims-profile.ts
@@ -1,14 +1,18 @@
 import { Observable } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { ClaimData } from 'iam-client-lib';
 import { IServiceEndpoint } from '@ew-did-registry/did-resolver-interface';
 
 export function mapClaimsProfile() {
   return (source: Observable<(IServiceEndpoint & ClaimData)[]>) => {
     return source.pipe(
-      mergeMap((claimsData: (IServiceEndpoint & ClaimData)[]) => {
-        const claimWithProfile = claimsData.filter(claim => !!claim.profile);
-        return claimWithProfile.length > 0 ? claimWithProfile : [{ profile: null }];
+      map((claimsData: (IServiceEndpoint & ClaimData)[]) => {
+        const claimWithProfile = claimsData.filter(claim => !!claim.profile).reduce((prev, next) => {
+          const isPrevNewerClaim = prev.iat > next.iat;
+          return isPrevNewerClaim ? prev : next;
+        }, { iat: 0 }) as IServiceEndpoint & ClaimData;
+
+        return claimWithProfile.profile;
       })
     );
   };

--- a/src/app/routes/assets/operators/map-claims-profile.ts
+++ b/src/app/routes/assets/operators/map-claims-profile.ts
@@ -1,0 +1,15 @@
+import { Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import { ClaimData } from 'iam-client-lib';
+import { IServiceEndpoint } from '@ew-did-registry/did-resolver-interface';
+
+export function mapClaimsProfile() {
+  return (source: Observable<(IServiceEndpoint & ClaimData)[]>) => {
+    return source.pipe(
+      mergeMap((claimsData: (IServiceEndpoint & ClaimData)[]) => {
+        const claimWithProfile = claimsData.filter(claim => !!claim.profile);
+        return claimWithProfile.length > 0 ? claimWithProfile : [{ profile: null }];
+      })
+    );
+  };
+}


### PR DESCRIPTION
Fixes 
1. problem when trying to register new asset and user didn't have user profile claim.
2. now should stop refreshing asset list when closing edit asset dialog component while not updating data.
3. now should stop closing edit asset dialog when clicking on backdrop.