### PR TITLE
[SWTCH-859] fixes to verification methods

### DIFF
--- a/src/app/routes/assets/asset-list/asset-list.component.html
+++ b/src/app/routes/assets/asset-list/asset-list.component.html
@@ -122,10 +122,9 @@
                                 <span>View Ownership History</span>
                             </button>
 
-<!--                             Verification Method-->
                             <button mat-menu-item class="btn-color-primary" *ngIf="AssetListType.MY_ASSETS === listType" (click)="viewVerificationMethod(element)">
                                 <mat-icon class="btn-color-primary btn-action-3">verified</mat-icon>
-                                <span>Verification</span>
+                                <span>Verification Method</span>
                             </button>
 
                             <ng-container *ngIf="listType === AssetListType.MY_ASSETS">

--- a/src/app/routes/assets/verification-method/verification-method.component.html
+++ b/src/app/routes/assets/verification-method/verification-method.component.html
@@ -43,9 +43,9 @@
     </ng-container>
     <div class="history-list-item mb-3 p-2">
         <mat-form-field class="mt-2" appearance="outline">
-            <input matInput [formControl]="publicKey" placeholder="Public Key" maxlength="256"
+            <input matInput [formControl]="publicKey" placeholder="Public Key"
                    autocomplete="off">
-            <mat-error>Public key is required. It should have at least 3 letters and no more than 256</mat-error>
+            <mat-error *ngIf="publicKey.invalid">{{getPublicKeyErrorMsg()}} </mat-error>
         </mat-form-field>
         <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never">
             <mat-select [formControl]="selectControl" placeholder="Select type">

--- a/src/app/routes/assets/verification-method/verification-method.component.html
+++ b/src/app/routes/assets/verification-method/verification-method.component.html
@@ -43,12 +43,12 @@
         </div>
     </ng-container>
     <div class="history-list-item mb-3 p-2">
-        <mat-form-field class="mt-2" appearance="outline">
+        <mat-form-field appearance="outline">
             <input matInput [formControl]="publicKey" placeholder="Public Key"
                    autocomplete="off">
             <mat-error *ngIf="publicKey.invalid">{{getPublicKeyErrorMsg()}} </mat-error>
         </mat-form-field>
-        <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never">
+        <mat-form-field appearance="outline" floatPlaceholder="never">
             <mat-select [formControl]="selectControl" placeholder="Select type">
                 <mat-option [value]="option[1]" *ngFor="let option of selectOptions">
                     <mat-icon class="color-info pr-2" svgIcon="ethereum-icon"></mat-icon>

--- a/src/app/routes/assets/verification-method/verification-method.component.html
+++ b/src/app/routes/assets/verification-method/verification-method.component.html
@@ -23,8 +23,9 @@
                             <div class="d-flex flex-row pl-2 align-items-baseline">
                                 <h4 class="small font-weight-600 mb-1">Public Key</h4>
                                 <span [tooltip]="publicKey?.publicKeyHex"
-                                      [cdkCopyToClipboard]="publicKey?.publicKeyHex"
-                                      (cdkCopyToClipboardCopied)="copied()"
+                                      appCopyToClipboard
+                                      [copyClipboard]="publicKey?.publicKeyHex"
+                                      message="Public key"
                                       class="pl-2 f-14 cursor-pointer">
                                     {{ publicKey?.publicKeyHex | didFormatMinifier }}
                                 </span>

--- a/src/app/routes/assets/verification-method/verification-method.component.html
+++ b/src/app/routes/assets/verification-method/verification-method.component.html
@@ -1,6 +1,6 @@
 <h4 mat-dialog-title class="mb-0 d-flex justify-content-between align-items-center">
     <div class="d-flex flex-column">
-        <span>Add Verification</span>
+        <span>Add Verification Method</span>
     </div>
     <button data-qa-id="close" mat-icon-button (click)="close()">
         <mat-icon>close</mat-icon>
@@ -9,7 +9,7 @@
 
 <div mat-dialog-content>
     <ng-container *ngIf="verificationsAmount > 0; else emptyList">
-        <div class="label color-white ml-1 pt-3 pl-2">{{verificationsAmount}} Verification(s)</div>
+        <div class="label color-white ml-1 pt-3 pl-2">{{verificationsAmount}} Verification Method(s)</div>
         <div class="history-list pt-2">
             <div class="history-list-item mb-3 p-2" *ngFor="let publicKey of dataSource">
                 <div class="d-flex flex-row justify-content-between align-items-center px-2">

--- a/src/app/routes/assets/verification-method/verification-method.component.ts
+++ b/src/app/routes/assets/verification-method/verification-method.component.ts
@@ -77,7 +77,7 @@ export class VerificationMethodComponent implements OnInit {
   }
 
   private copied(): void {
-    this.toastr.success('Did successfully copied to clipboard.');
+    this.toastr.success('Public key successfully copied to clipboard.');
   }
 
 }

--- a/src/app/routes/assets/verification-method/verification-method.component.ts
+++ b/src/app/routes/assets/verification-method/verification-method.component.ts
@@ -5,7 +5,6 @@ import { FormControl, Validators } from '@angular/forms';
 import { PageEvent } from '@angular/material/paginator';
 import { AlgorithmsEnum } from '../models/algorithms.enum';
 import { ToastrService } from 'ngx-toastr';
-import { textDefaultsValidators } from '../../../utils/validators/text-defaults-validators';
 
 export interface PublicKey {
   publicKeyHex: string;
@@ -24,7 +23,7 @@ export class VerificationMethodComponent implements OnInit {
   dataSource: PublicKey[] = [];
   selectControl = new FormControl('', [Validators.required]);
   publicKey = new FormControl('',
-    textDefaultsValidators
+    [Validators.required, Validators.pattern(new RegExp('0x[A-Fa-f0-9]{66}'))]
   );
   selectOptions = Object.entries(AlgorithmsEnum);
   private publicKeys;
@@ -59,6 +58,18 @@ export class VerificationMethodComponent implements OnInit {
     this.verificationService.updateDocumentAndReload(this.dialogData.id, this.publicKey.value).subscribe((publicKeys) => {
       this.handleLoadedPublicKeys(publicKeys);
     });
+  }
+
+  getPublicKeyErrorMsg() {
+    if (this.publicKey.hasError('required')) {
+      return 'This field is required';
+    }
+
+    if (this.publicKey.hasError('pattern')) {
+      return 'Invalid input. Public key must start with "0x" to be followed by 66 Hexadecimal characters.';
+    }
+
+    return '';
   }
 
   private handleLoadedPublicKeys(publicKeys): void {

--- a/src/app/routes/assets/verification-method/verification-method.component.ts
+++ b/src/app/routes/assets/verification-method/verification-method.component.ts
@@ -60,7 +60,6 @@ export class VerificationMethodComponent implements OnInit {
   }
 
   getPublicKeyErrorMsg() {
-    debugger;
     if (this.publicKey.hasError('required')) {
       return 'This field is required';
     }

--- a/src/app/routes/assets/verification-method/verification-method.component.ts
+++ b/src/app/routes/assets/verification-method/verification-method.component.ts
@@ -4,6 +4,7 @@ import { VerificationService } from './verification.service';
 import { FormControl, Validators } from '@angular/forms';
 import { PageEvent } from '@angular/material/paginator';
 import { AlgorithmsEnum } from '../models/algorithms.enum';
+import { isHexValidator } from '../../../utils/validators/is-hex.validator';
 
 export interface PublicKey {
   publicKeyHex: string;
@@ -22,7 +23,7 @@ export class VerificationMethodComponent implements OnInit {
   dataSource: PublicKey[] = [];
   selectControl = new FormControl('', [Validators.required]);
   publicKey = new FormControl('',
-    [Validators.required, Validators.pattern(new RegExp('0x[A-Fa-f0-9]{66}'))]
+    [Validators.required, isHexValidator]
   );
   selectOptions = Object.entries(AlgorithmsEnum);
   private publicKeys;
@@ -59,12 +60,13 @@ export class VerificationMethodComponent implements OnInit {
   }
 
   getPublicKeyErrorMsg() {
+    debugger;
     if (this.publicKey.hasError('required')) {
       return 'This field is required';
     }
 
-    if (this.publicKey.hasError('pattern')) {
-      return 'Invalid input. Public key must start with "0x" to be followed by 66 Hexadecimal characters.';
+    if (this.publicKey.hasError('isHexInvalid')) {
+      return 'Invalid input. Public key must start with "0x" to be followed by 66 or 130 Hexadecimal characters.';
     }
 
     return '';

--- a/src/app/routes/assets/verification-method/verification-method.component.ts
+++ b/src/app/routes/assets/verification-method/verification-method.component.ts
@@ -4,7 +4,6 @@ import { VerificationService } from './verification.service';
 import { FormControl, Validators } from '@angular/forms';
 import { PageEvent } from '@angular/material/paginator';
 import { AlgorithmsEnum } from '../models/algorithms.enum';
-import { ToastrService } from 'ngx-toastr';
 
 export interface PublicKey {
   publicKeyHex: string;
@@ -30,8 +29,7 @@ export class VerificationMethodComponent implements OnInit {
 
   constructor(private dialogRef: MatDialogRef<VerificationMethodComponent>,
               @Inject(MAT_DIALOG_DATA) private dialogData: any,
-              private verificationService: VerificationService,
-              private toastr: ToastrService) {
+              private verificationService: VerificationService) {
   }
 
   get isFormDisabled() {
@@ -85,10 +83,6 @@ export class VerificationMethodComponent implements OnInit {
   private loadPublicKeys(): void {
     this.verificationService.getPublicKeys(this.dialogData.id, true)
       .subscribe(publicKeys => this.handleLoadedPublicKeys(publicKeys));
-  }
-
-  private copied(): void {
-    this.toastr.success('Public key successfully copied to clipboard.');
   }
 
 }

--- a/src/app/shared/directives/copyToClipboard/copy-to-clipboard.directive.ts
+++ b/src/app/shared/directives/copyToClipboard/copy-to-clipboard.directive.ts
@@ -1,0 +1,46 @@
+import { Directive, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+
+@Directive({
+  selector: '[appCopyToClipboard]'
+})
+export class CopyToClipboardDirective {
+
+  @Input() public copyClipboard: string;
+  @Input() public message: string;
+
+  @Output() public copied: EventEmitter<string> = new EventEmitter<string>();
+
+  constructor(private toastr: ToastrService) {
+  }
+
+  @HostListener('click', ['$event'])
+  public onClick(event: MouseEvent): void {
+
+    event.preventDefault();
+    if (!this.copyClipboard) {
+      return;
+    }
+
+    const listener = (e: ClipboardEvent) => {
+      const clipboard = e.clipboardData || (window as any).clipboardData;
+      clipboard.setData('text', this.copyClipboard.toString());
+      e.preventDefault();
+
+      this.displayToastrMessage();
+
+      this.copied.emit(this.copyClipboard);
+    };
+
+    document.addEventListener('copy', listener, false);
+    document.execCommand('copy');
+    document.removeEventListener('copy', listener, false);
+  }
+
+  displayToastrMessage(): void {
+    if (this.message) {
+      this.toastr.success(`${this.message} successfully copied to clipboard.`);
+    }
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -65,7 +65,43 @@ import { MatDialogModule } from '@angular/material/dialog';
 
 import { SmartSearchComponent } from './components/smart-search/smart-search.component';
 import { ReplaceUnderscorePipe } from './pipes/replace-underscore.pipe';
+import { CopyToClipboardDirective } from './directives/copyToClipboard/copy-to-clipboard.directive';
 
+
+const MATERIAL_MODULES = [
+  MatAutocompleteModule,
+  MatButtonModule,
+  MatButtonToggleModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatChipsModule,
+  MatTableModule,
+  MatDatepickerModule,
+  MatDialogModule,
+  MatExpansionModule,
+  MatFormFieldModule,
+  MatGridListModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule,
+  MatMenuModule,
+  MatPaginatorModule,
+  MatProgressBarModule,
+  MatProgressSpinnerModule,
+  MatRadioModule,
+  MatRippleModule,
+  MatSelectModule,
+  MatSidenavModule,
+  MatSlideToggleModule,
+  MatSliderModule,
+  MatSnackBarModule,
+  MatSortModule,
+  MatTabsModule,
+  MatToolbarModule,
+  MatTooltipModule,
+  MatNativeDateModule,
+  MatStepperModule,
+];
 
 // https://angular.io/styleguide#!#04-10
 @NgModule({
@@ -91,39 +127,7 @@ import { ReplaceUnderscorePipe } from './pipes/replace-underscore.pipe';
     TooltipModule.forRoot(),
     PopoverModule.forRoot(),
     TypeaheadModule.forRoot(),
-    // Material Modules
-    MatAutocompleteModule,
-    MatButtonModule,
-    MatButtonToggleModule,
-    MatCardModule,
-    MatCheckboxModule,
-    MatChipsModule,
-    MatTableModule,
-    MatDatepickerModule,
-    MatDialogModule,
-    MatExpansionModule,
-    MatFormFieldModule,
-    MatGridListModule,
-    MatIconModule,
-    MatInputModule,
-    MatListModule,
-    MatMenuModule,
-    MatPaginatorModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule,
-    MatRadioModule,
-    MatRippleModule,
-    MatSelectModule,
-    MatSidenavModule,
-    MatSlideToggleModule,
-    MatSliderModule,
-    MatSnackBarModule,
-    MatSortModule,
-    MatTabsModule,
-    MatToolbarModule,
-    MatTooltipModule,
-    MatNativeDateModule,
-    MatStepperModule
+    MATERIAL_MODULES
   ],
   providers: [
     ColorsService
@@ -138,7 +142,8 @@ import { ReplaceUnderscorePipe } from './pipes/replace-underscore.pipe';
     MinifiedDidViewerDirective,
     MinifiedDidViewerDialogComponent,
     SmartSearchComponent,
-    ReplaceUnderscorePipe
+    ReplaceUnderscorePipe,
+    CopyToClipboardDirective
   ],
   exports: [
     CommonModule,
@@ -170,41 +175,10 @@ import { ReplaceUnderscorePipe } from './pipes/replace-underscore.pipe';
     MinifiedDidViewerDirective,
     DidFormatMinifierPipe,
     EnrolmentListComponent,
-    // Material Modules
-    MatAutocompleteModule,
-    MatButtonModule,
-    MatButtonToggleModule,
-    MatCardModule,
-    MatCheckboxModule,
-    MatChipsModule,
-    MatTableModule,
-    MatDatepickerModule,
-    MatDialogModule,
-    MatExpansionModule,
-    MatFormFieldModule,
-    MatGridListModule,
-    MatIconModule,
-    MatInputModule,
-    MatListModule,
-    MatMenuModule,
-    MatPaginatorModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule,
-    MatRadioModule,
-    MatRippleModule,
-    MatSelectModule,
-    MatSidenavModule,
-    MatSlideToggleModule,
-    MatSliderModule,
-    MatSnackBarModule,
-    MatSortModule,
-    MatTabsModule,
-    MatToolbarModule,
-    MatTooltipModule,
-    MatNativeDateModule,
-    MatStepperModule,
+    MATERIAL_MODULES,
     SmartSearchComponent,
-    ReplaceUnderscorePipe
+    ReplaceUnderscorePipe,
+    CopyToClipboardDirective
   ],
   entryComponents: [MinifiedDidViewerDialogComponent]
 })

--- a/src/app/utils/validators/is-hex.validator.spec.ts
+++ b/src/app/utils/validators/is-hex.validator.spec.ts
@@ -2,8 +2,8 @@ import { isHexValidator } from './is-hex.validator';
 import { FormControl } from '@angular/forms';
 
 describe('tests for isHexValidator', () => {
-  const hexWithoutBeggining66 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456';
-  const hexWithoutBeggining130 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234';
+  const hexWithoutBeginning66 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456';
+  const hexWithoutBeginning130 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234';
   it('should return null when passing undefined', () => {
     expect(isHexValidator(new FormControl())).toEqual(null);
   });
@@ -13,11 +13,11 @@ describe('tests for isHexValidator', () => {
   });
 
   it('should return true when value do not start with 0x', () => {
-    expect(isHexValidator(new FormControl('a' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+    expect(isHexValidator(new FormControl('a' + hexWithoutBeginning66))).toEqual({ isHexInvalid: true });
   });
 
   it('should return false when value start with 0x and is followed by 66 characters', () => {
-    expect(isHexValidator(new FormControl('0x' + hexWithoutBeggining66))).toEqual(null);
+    expect(isHexValidator(new FormControl('0x' + hexWithoutBeginning66))).toEqual(null);
   });
 
   it('should return true when value contain less than 66 characters followed by 0x', () => {
@@ -25,18 +25,18 @@ describe('tests for isHexValidator', () => {
   });
 
   it('should return false when value start with 0x and is followed by 130 characters', () => {
-    expect(isHexValidator(new FormControl('0x' + hexWithoutBeggining130))).toEqual(null);
+    expect(isHexValidator(new FormControl('0x' + hexWithoutBeginning130))).toEqual(null);
   });
 
   it('should return true when value start with 0x and is followed by 67 characters', () => {
-    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeginning66))).toEqual({ isHexInvalid: true });
   });
 
   it('should return true when value start with 0x and is followed by 131 characters', () => {
-    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeggining130))).toEqual({ isHexInvalid: true });
+    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeginning130))).toEqual({ isHexInvalid: true });
   });
 
   it('should return true when value start with different value but is followed by proper hex', () => {
-    expect(isHexValidator(new FormControl('Abc0x' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+    expect(isHexValidator(new FormControl('Abc0x' + hexWithoutBeginning66))).toEqual({ isHexInvalid: true });
   });
 });

--- a/src/app/utils/validators/is-hex.validator.spec.ts
+++ b/src/app/utils/validators/is-hex.validator.spec.ts
@@ -1,0 +1,42 @@
+import { isHexValidator } from './is-hex.validator';
+import { FormControl } from '@angular/forms';
+
+describe('tests for isHexValidator', () => {
+  const hexWithoutBeggining66 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456';
+  const hexWithoutBeggining130 = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff123456aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234';
+  it('should return null when passing undefined', () => {
+    expect(isHexValidator(new FormControl())).toEqual(null);
+  });
+
+  it('should return null when passing empty string', () => {
+    expect(isHexValidator(new FormControl(''))).toEqual(null);
+  });
+
+  it('should return true when value do not start with 0x', () => {
+    expect(isHexValidator(new FormControl('a' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+  });
+
+  it('should return false when value start with 0x and is followed by 66 characters', () => {
+    expect(isHexValidator(new FormControl('0x' + hexWithoutBeggining66))).toEqual(null);
+  });
+
+  it('should return true when value contain less than 66 characters followed by 0x', () => {
+    expect(isHexValidator(new FormControl('0x' + '123'))).toEqual({ isHexInvalid: true });
+  });
+
+  it('should return false when value start with 0x and is followed by 130 characters', () => {
+    expect(isHexValidator(new FormControl('0x' + hexWithoutBeggining130))).toEqual(null);
+  });
+
+  it('should return true when value start with 0x and is followed by 67 characters', () => {
+    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+  });
+
+  it('should return true when value start with 0x and is followed by 131 characters', () => {
+    expect(isHexValidator(new FormControl('0x1' + hexWithoutBeggining130))).toEqual({ isHexInvalid: true });
+  });
+
+  it('should return true when value start with different value but is followed by proper hex', () => {
+    expect(isHexValidator(new FormControl('Abc0x' + hexWithoutBeggining66))).toEqual({ isHexInvalid: true });
+  });
+});

--- a/src/app/utils/validators/is-hex.validator.ts
+++ b/src/app/utils/validators/is-hex.validator.ts
@@ -1,12 +1,17 @@
 import { AbstractControl } from '@angular/forms';
 
+const hexRegex = new RegExp('^(0x)([0-9a-fA-F])');
+
+// 0x + 66
+const SHORT_HEX = 68;
+// 0x + 130
+const LONG_HEX = 132;
+
 export function isHexValidator(control: AbstractControl) {
   if (!control.value) {
     return null;
   }
-  const hexRegex = new RegExp('^(0x)([0-9a-fA-F])');
-  // 0x + 66 = 68, 0x + 130 = 132.
-  const validLength = control.value.length === 68 || control.value.length === 132;
+  const validLength = control.value.length === SHORT_HEX || control.value.length === LONG_HEX;
   if (hexRegex.test(control.value) && validLength) {
     return null;
   }

--- a/src/app/utils/validators/is-hex.validator.ts
+++ b/src/app/utils/validators/is-hex.validator.ts
@@ -1,0 +1,17 @@
+import { AbstractControl } from '@angular/forms';
+
+export function isHexValidator(control: AbstractControl) {
+  if (!control.value) {
+    return null;
+  }
+  const hexRegex = new RegExp('^(0x)([0-9a-fA-F])');
+  // 0x + 66 = 68, 0x + 130 = 132.
+  const validLength = control.value.length === 68 || control.value.length === 132;
+  if (hexRegex.test(control.value) && validLength) {
+    return null;
+  }
+  return {
+    isHexInvalid: true
+  };
+
+}


### PR DESCRIPTION
Fixes to adding verification methods:
1. Added validation to accept Hex inputs as public key. Thanks to @JGiter for providing regex.
2. Change labels
3. Change toastr message to display Public key instead of Did.
4. Removed not needed css classes.

Additionaly added directive for copying to clipboard and displaying message with toastr - this can be used in multiple places where clipboard functionality is needed.