### PR TITLE
bug(request-claim): cast role.version to string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1838,9 +1838,9 @@
       }
     },
     "@energyweb/iam-contracts": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.10.1.tgz",
-      "integrity": "sha512-feBHPT3z37HpQMDdUa7jpjb2e5NXwLpcnPjDi9OITzahsNGR7djqk1ffeDteMSLNwRGZMY3L6MRY/Y8oEUfukw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.11.0.tgz",
+      "integrity": "sha512-EinoPzFmiWkMcl+1wF06kNL0QwNEm8ZgBaVgaBahetWFE+TXWkXP9R1tw386wO8zX2bAcz/D7KB7miM4lTiDpQ==",
       "requires": {
         "@openzeppelin/contracts": "3.4.1",
         "ethers": "4.0.45"
@@ -13207,12 +13207,12 @@
       }
     },
     "iam-client-lib": {
-      "version": "3.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-3.0.0-alpha.16.tgz",
-      "integrity": "sha512-8TE6MH7DTolRiqyZ+d1x+M9KItvk69agmna1Zhf+NfzkmHw1ur4SEqq2iywfiJLkL5TUe1R7G/2rENxIR2vu2g==",
+      "version": "3.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-3.0.0-alpha.17.tgz",
+      "integrity": "sha512-S5PBxv5EB6wkcgEfh45TaF+Bfw87oQygSztz1lIdnm634zmUBiXpfx+uvjiM6pEKc/nxHTtu1WzmSzUrYALFnw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@energyweb/iam-contracts": "1.10.1",
+        "@energyweb/iam-contracts": "1.11.0",
         "@ensdomains/ens": "^0.4.5",
         "@ew-did-registry/claims": "0.5.2-alpha.1045.0",
         "@ew-did-registry/did": "0.5.2-alpha.1045.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "enhanced-resolve": "3.3.0",
     "fullcalendar": "3.9.0",
     "hammerjs": "^2.0.8",
-    "iam-client-lib": "^3.0.0-alpha.16",
+    "iam-client-lib": "^3.0.0-alpha.17",
     "intl": "1.2.5",
     "jquery": "^3.5.0",
     "jquery-slimscroll": "1.3.8",

--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -2,7 +2,7 @@ import { Component, HostListener, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Asset, ENSNamespaceTypes, PreconditionTypes } from 'iam-client-lib';
+import { Asset, ENSNamespaceTypes, IRoleDefinition, PreconditionTypes } from 'iam-client-lib';
 import { Claim } from 'iam-client-lib/dist/src/cacheServerClient/cacheServerClient.types';
 import { ToastrService } from 'ngx-toastr';
 import { IamService } from 'src/app/shared/services/iam.service';
@@ -15,7 +15,7 @@ import { ViewColorsSetter, SubjectElements } from '../models/view-colors-setter'
 const SWAL = require('sweetalert');
 
 const TOASTR_HEADER = 'Enrolment';
-const DEFAULT_CLAIM_TYPE_VERSION = '1.0.0';
+const DEFAULT_CLAIM_TYPE_VERSION = 1;
 const REDIRECT_TO_ENROLMENT = true;
 const EnrolForType = {
   ME: 'me',
@@ -43,20 +43,7 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
     enrolFor: EnrolForType.ME,
     assetDid: ''
   });
-  public fieldList: {
-    fieldType: string,
-    label: string,
-    required: boolean,
-    minLength: number,
-    maxLength: number,
-    pattern: string,
-    minValue: number,
-    maxValue: number,
-    minDate: string,
-    maxDate: string,
-    minDateValue: Date,
-    maxDateValue: Date
-  }[];
+  public fieldList: IRoleDefinition['fields'];
 
   public orgAppDetails: any;
   public roleList: any;
@@ -81,7 +68,7 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
   private callbackUrl: string;
   private defaultRole: string;
   private roleType: string;
-  private selectedRole: any;
+  private selectedRole: IRoleDefinition;
   private selectedNamespace: string;
   private stayLoggedIn = false;
 
@@ -224,7 +211,8 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
           let claim = {
             fields: JSON.parse(JSON.stringify(fields)),
             claimType: this.selectedNamespace,
-            claimTypeVersion: this.selectedRole.version || DEFAULT_CLAIM_TYPE_VERSION
+            // toString() on claimTypeVersion because expected type on iam-cache-server is string but roleDefinition type is 
+            claimTypeVersion: (this.selectedRole.version || DEFAULT_CLAIM_TYPE_VERSION).toString()
           };
 
           await this.iamService.iam.createClaimRequest({


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/SWTCH-982.
iam-cache-server is expecting a string for `selectedRole.version` and so casting to `string`.

I believe this is a regression introduced by https://energyweb.atlassian.net/browse/SWTCH-655 somewhere because `IRoleDefinition` now has `version` as a string. The ultimate solution is to migrate all of the legacy roles with their old string version to new integer version.