### PR TITLE
fix(SWTCH-990): not working back navigation when navigating from a url with redirect inside.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { MatIconRegistry } from "@angular/material/icon";
 import { DomSanitizer } from "@angular/platform-browser";
 
 import { SettingsService } from './core/settings/settings.service';
+import { UrlService } from './shared/services/url-service/url.service';
 
 @Component({
     selector: 'app-root',
@@ -22,7 +23,10 @@ export class AppComponent implements OnInit {
     @HostBinding('class.aside-toggled') get asideToggled() { return this.settings.getLayoutSetting('asideToggled'); };
     @HostBinding('class.aside-collapsed-text') get isCollapsedText() { return this.settings.getLayoutSetting('isCollapsedText'); };
 
-    constructor(public settings: SettingsService, private matIconRegistry: MatIconRegistry, private domSanitizer: DomSanitizer) {
+    constructor(public settings: SettingsService,
+                private matIconRegistry: MatIconRegistry,
+                private domSanitizer: DomSanitizer,
+                private urlHistoryService: UrlService) {
         this.matIconRegistry.addSvgIcon(
             "wallet-icon",
             this.domSanitizer.bypassSecurityTrustResourceUrl("../assets/img/icons/wallet-icon.svg")
@@ -98,7 +102,7 @@ export class AppComponent implements OnInit {
         this.matIconRegistry.addSvgIcon(
             "view-qr-icon",
             this.domSanitizer.bypassSecurityTrustResourceUrl("../assets/img/icons/qr-icon.svg")
-        );    
+        );
         this.matIconRegistry.addSvgIcon(
             "new-claim-icon",
             this.domSanitizer.bypassSecurityTrustResourceUrl("../assets/img/icons/new-claim-icon.svg")
@@ -159,6 +163,7 @@ export class AppComponent implements OnInit {
     }
 
     ngOnInit() {
+      this.urlHistoryService.init();
         // prevent empty links to reload the page
         document.addEventListener('click', e => {
             const target = e.target as HTMLElement;

--- a/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
+++ b/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { EnrolmentListComponent } from '../../enrolment/enrolment-list/enrolment-list.component';
-import { Location } from '@angular/common';
+import { UrlService } from '../../../shared/services/url-service/url.service';
 
 @Component({
   selector: 'app-asset-enrolment-list',
@@ -28,7 +28,7 @@ export class AssetEnrolmentListComponent implements OnInit, OnDestroy {
   private subscription$ = new Subject();
 
   constructor(private activatedRoute: ActivatedRoute,
-              private location: Location) {
+              private urlService: UrlService) {
   }
 
   ngOnDestroy(): void {
@@ -51,6 +51,18 @@ export class AssetEnrolmentListComponent implements OnInit, OnDestroy {
   }
 
   back() {
-    this.location.back();
+    this.urlService.previous.pipe(
+      takeUntil(this.subscription$)
+    ).subscribe(url => {
+      this.navigateBack(url);
+    });
+  }
+
+  navigateBack(url: string): void {
+    if (url.includes('returnUrl')) {
+      this.urlService.goTo('assets');
+      return;
+    }
+    this.urlService.back();
   }
 }

--- a/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
+++ b/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
@@ -53,12 +53,11 @@ export class AssetEnrolmentListComponent implements OnInit, OnDestroy {
   back() {
     this.urlService.previous.pipe(
       takeUntil(this.subscription$)
-    ).subscribe(url => {
-      this.navigateBack(url);
-    });
+    ).subscribe(url => this.navigateBackHandler(url));
   }
 
-  navigateBack(url: string): void {
+  private navigateBackHandler(url: string): void {
+    // 'returnUrl' is taken as an indicator back() would trigger an loop back to asset-enrolment
     if (url.includes('returnUrl')) {
       this.urlService.goTo('assets');
       return;

--- a/src/app/shared/services/url-service/url.service.ts
+++ b/src/app/shared/services/url-service/url.service.ts
@@ -9,7 +9,7 @@ import { Location } from '@angular/common';
 })
 export class UrlService {
   private previousUrl = new BehaviorSubject<string>(null);
-  private currentUrl = new BehaviorSubject(null);
+  private currentUrl = new BehaviorSubject<string>(null);
 
   get previous(): Observable<string> {
     return this.previousUrl.asObservable();

--- a/src/app/shared/services/url-service/url.service.ts
+++ b/src/app/shared/services/url-service/url.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Location } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UrlService {
+  private previousUrl = new BehaviorSubject<string>(null);
+  private currentUrl = new BehaviorSubject(null);
+
+  get previous(): Observable<string> {
+    return this.previousUrl.asObservable();
+  }
+
+  get current() {
+    return this.currentUrl.asObservable();
+  }
+
+  constructor(private router: Router,
+              private location: Location) {
+  }
+
+  init() {
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd)
+    ).subscribe((e: NavigationEnd) => this.updateHistory(e));
+  }
+
+  goTo(url: string) {
+    this.router.navigateByUrl(url);
+  }
+
+  back(): void {
+    this.location.back();
+  }
+
+  private updateHistory(event: NavigationEnd): void {
+    this.previousUrl.next(this.currentUrl.getValue());
+    this.currentUrl.next(event.url);
+  }
+}


### PR DESCRIPTION
Previous solution wasn't working when navigating to asset enrolments from enrol/dashboard redirect. Back button was navigating to that page, but it was immediately redirecting to asset enrolments again. In that case back button will navigate to `asset` url which is my asset list.