### PR TITLE
SWTCH-978 adjust role name field validation

### DIFF
--- a/src/app/routes/applications/new-application/new-application.component.html
+++ b/src/app/routes/applications/new-application/new-application.component.html
@@ -40,10 +40,21 @@
               <div class="row">
                 <div class="col-lg-12">
                   <mat-label class="ml-3 pl-1">Application Namespace</mat-label>
-                  <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never" *ngIf="viewType !== ViewType.UPDATE" >
-                    <input matInput autocomplete="off" formControlName="appName" type="text" appBlockPaste placeholder="Application Namespace" required
-                      oninput="this.value = this.value.toLowerCase()" (keypress)="alphaNumericOnly($event)" minlength="3" maxlength="256"/>
-                      <mat-error>Application Namespace is <strong>required</strong></mat-error>
+                  <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never"
+                                  *ngIf="viewType !== ViewType.UPDATE">
+                    <input matInput autocomplete="off" formControlName="appName" type="text" appBlockPaste
+                           placeholder="Application Namespace" required
+                           oninput="this.value = this.value.toLowerCase()" (keypress)="alphaNumericOnly($event)"
+                           minlength="3" maxlength="256"/>
+                    <mat-error *ngIf="appForm.get('appName').hasError('required')">
+                      Application Namespace is <strong>required</strong>
+                    </mat-error>
+                    <mat-error *ngIf="appForm.get('appName').hasError( 'minlength')">
+                      Application Namespace need to have at least 3 characters.
+                    </mat-error>
+                    <mat-error *ngIf="appForm.get('appName').hasError('isAlphaNumericInvalid')">
+                      Application Namespace can only contain alphanumeric characters.
+                    </mat-error>
                   </mat-form-field>
                 </div>
                 <div *ngIf="appForm.get('appName').value" class="ml-3 card card-result d-flex flex-row justify-content-start align-items-center shadow-none d-flex pt-3 pb-2 mb-3 mr-3">

--- a/src/app/routes/applications/new-application/new-application.component.html
+++ b/src/app/routes/applications/new-application/new-application.component.html
@@ -40,7 +40,7 @@
               <div class="row">
                 <div class="col-lg-12">
                   <mat-label class="ml-3 pl-1">Application Namespace</mat-label>
-                  <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never"
+                  <mat-form-field class="mt-2 multi-errors" appearance="outline" floatPlaceholder="never"
                                   *ngIf="viewType !== ViewType.UPDATE">
                     <input matInput autocomplete="off" formControlName="appName" type="text" appBlockPaste
                            placeholder="Application Namespace" required

--- a/src/app/routes/applications/new-application/new-application.component.scss
+++ b/src/app/routes/applications/new-application/new-application.component.scss
@@ -1,0 +1,5 @@
+.multi-errors ::ng-deep {
+  .mat-form-field-subscript-wrapper {
+    position: relative;
+  }
+}

--- a/src/app/routes/applications/new-application/new-application.component.ts
+++ b/src/app/routes/applications/new-application/new-application.component.ts
@@ -10,6 +10,7 @@ import { ConfirmationDialogComponent } from '../../widgets/confirmation-dialog/c
 import { ViewType } from '../new-organization/new-organization.component';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
+import { isAlphanumericValidator } from '../../../utils/validators/is-alphanumeric.validator';
 
 @Component({
   selector: 'app-new-application',
@@ -26,7 +27,7 @@ export class NewApplicationComponent implements OnInit, AfterViewInit {
 
   public appForm = this.fb.group({
     orgNamespace: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],
-    appName: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],
+    appName: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(256), isAlphanumericValidator]],
     namespace: '',
     data: this.fb.group({
       applicationName: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],

--- a/src/app/routes/applications/new-role/new-role.component.html
+++ b/src/app/routes/applications/new-role/new-role.component.html
@@ -32,7 +32,8 @@
                     <input matInput autocomplete="off" formControlName="roleName" appBlockPaste type="text"
                       placeholder="Role Name" required oninput="this.value = this.value.toLowerCase()"
                       (keypress)="alphaNumericOnly($event)" minlength="3" maxlength="256" />
-                    <mat-error>Role Name is <strong>required</strong></mat-error>
+                    <mat-error *ngIf="controlHasError('roleName', 'required')">Role Name is <strong>required</strong></mat-error>
+                    <mat-error *ngIf="controlHasError('roleName', 'minlength')">Role Name need to have at least 3 characters</mat-error>
                   </mat-form-field>
                 </div>
                 <div *ngIf="roleForm.get('roleName').value"

--- a/src/app/routes/applications/new-role/new-role.component.html
+++ b/src/app/routes/applications/new-role/new-role.component.html
@@ -28,7 +28,7 @@
               <div class="row">
                 <div class="col-lg-12">
                   <mat-label class="ml-3 pl-1">Role Name</mat-label>
-                  <mat-form-field class="mt-2" appearance="outline" floatPlaceholder="never">
+                  <mat-form-field class="mt-2 multi-errors" appearance="outline" floatPlaceholder="never">
                     <input matInput autocomplete="off" formControlName="roleName" appBlockPaste type="text"
                       placeholder="Role Name" required oninput="this.value = this.value.toLowerCase()"
                       (keypress)="alphaNumericOnly($event)" minlength="3" maxlength="256" />

--- a/src/app/routes/applications/new-role/new-role.component.html
+++ b/src/app/routes/applications/new-role/new-role.component.html
@@ -33,7 +33,8 @@
                       placeholder="Role Name" required oninput="this.value = this.value.toLowerCase()"
                       (keypress)="alphaNumericOnly($event)" minlength="3" maxlength="256" />
                     <mat-error *ngIf="controlHasError('roleName', 'required')">Role Name is <strong>required</strong></mat-error>
-                    <mat-error *ngIf="controlHasError('roleName', 'minlength')">Role Name need to have at least 3 characters</mat-error>
+                    <mat-error *ngIf="controlHasError('roleName', 'minlength')">Role Name need to have at least 3 characters.</mat-error>
+                    <mat-error *ngIf="controlHasError('roleName', 'isAlphaNumericInvalid')">Role Name can only contain alphanumeric characters.</mat-error>
                   </mat-form-field>
                 </div>
                 <div *ngIf="roleForm.get('roleName').value"

--- a/src/app/routes/applications/new-role/new-role.component.scss
+++ b/src/app/routes/applications/new-role/new-role.component.scss
@@ -1,4 +1,4 @@
-:host ::ng-deep {
+.multi-errors ::ng-deep {
   .mat-form-field-subscript-wrapper {
     position: relative;
   }

--- a/src/app/routes/applications/new-role/new-role.component.scss
+++ b/src/app/routes/applications/new-role/new-role.component.scss
@@ -1,0 +1,5 @@
+:host ::ng-deep {
+  .mat-form-field-subscript-wrapper {
+    position: relative;
+  }
+}

--- a/src/app/routes/applications/new-role/new-role.component.ts
+++ b/src/app/routes/applications/new-role/new-role.component.ts
@@ -492,7 +492,14 @@ export class NewRoleComponent implements OnInit, AfterViewInit, OnDestroy {
     this.showFieldsForm = false;
   }
 
+  isRoleNameInValid(): boolean {
+    return this.roleForm.get('roleName').valid;
+  }
+
   async proceedSettingIssuer() {
+    if (!this.isRoleNameInValid()) {
+      return;
+    }
     of(null)
     .pipe(
         take(1),

--- a/src/app/routes/applications/new-role/new-role.component.ts
+++ b/src/app/routes/applications/new-role/new-role.component.ts
@@ -68,7 +68,7 @@ export class NewRoleComponent implements OnInit, AfterViewInit, OnDestroy {
   public roleForm     = this.fb.group({
     roleType: [null, Validators.required],
     parentNamespace: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],
-    roleName: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],
+    roleName: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(256)]],
     namespace: '',
     data: this.fb.group({
       version: 1,
@@ -310,6 +310,10 @@ export class NewRoleComponent implements OnInit, AfterViewInit, OnDestroy {
       this.fieldsForm.get('validation').get('minDate'),
       this.fieldsForm.get('validation').get('maxDate')
     );
+  }
+
+  controlHasError(control: string, errorType: string) {
+    return this.roleForm.get(control).hasError(errorType);
   }
 
   alphaNumericOnly(event: any, includeDot?: boolean) {

--- a/src/app/routes/applications/new-role/new-role.component.ts
+++ b/src/app/routes/applications/new-role/new-role.component.ts
@@ -19,6 +19,7 @@ import { MatStepper } from '@angular/material/stepper';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatTableDataSource } from '@angular/material/table';
 import { Observable, of } from 'rxjs';
+import { isAlphanumericValidator } from '../../../utils/validators/is-alphanumeric.validator';
 
 export const RoleType = {
   ORG: 'org',
@@ -68,7 +69,7 @@ export class NewRoleComponent implements OnInit, AfterViewInit, OnDestroy {
   public roleForm     = this.fb.group({
     roleType: [null, Validators.required],
     parentNamespace: ['', Validators.compose([Validators.required, Validators.minLength(3), Validators.maxLength(256)])],
-    roleName: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(256)]],
+    roleName: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(256), isAlphanumericValidator]],
     namespace: '',
     data: this.fb.group({
       version: 1,

--- a/src/app/utils/validators/is-alphanumeric.validator.spec.ts
+++ b/src/app/utils/validators/is-alphanumeric.validator.spec.ts
@@ -1,0 +1,24 @@
+import { FormControl } from '@angular/forms';
+import { isAlphanumericValidator } from './is-alphanumeric.validator';
+
+describe('tests for isAlphanumericValidator', () => {
+  it('should return null when passing empty string', () => {
+    expect(isAlphanumericValidator(new FormControl(''))).toEqual(null);
+  });
+
+  it('should return true when value is only a whitespace', () => {
+    expect(isAlphanumericValidator(new FormControl(' '))).toEqual({isAlphaNumericInvalid: true});
+  });
+
+  it('should return true when value contains whitespace between characters', () => {
+    expect(isAlphanumericValidator(new FormControl('a b'))).toEqual({isAlphaNumericInvalid: true});
+  });
+
+  it('should return null when passing a value without whitespaces', () => {
+    expect(isAlphanumericValidator(new FormControl('ab12ZX'))).toEqual(null);
+  });
+
+  it('should true when contains special characters', () => {
+    expect(isAlphanumericValidator(new FormControl('@!'))).toEqual({isAlphaNumericInvalid: true});
+  });
+});

--- a/src/app/utils/validators/is-alphanumeric.validator.ts
+++ b/src/app/utils/validators/is-alphanumeric.validator.ts
@@ -1,0 +1,16 @@
+import { AbstractControl } from '@angular/forms';
+
+const alphaNumericRegex = new RegExp(/^[a-z0-9]+$/i);
+
+export function isAlphanumericValidator(control: AbstractControl) {
+  if (!control.value) {
+    return null;
+  }
+  if (alphaNumericRegex.test(control.value)) {
+    return null;
+  }
+  return {
+    isAlphaNumericInvalid: true
+  };
+
+}


### PR DESCRIPTION
Fixes for Role name (Role creation) and Application Namespace (Application creation).
For both:
1. Displays messege that field need to have at least 3 characters.
2. Field need to contain only alphanumeric values.
3. Can display multiple errors below a field - not like previously that field is required.

Fix only for Role name:
When Role name have incorrect value then user can't go further anymore.