### PR TITLE
SWTCH-1046 fix feature flag

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,7 +43,7 @@ const providers: Provider[] = [
       configService.loadConfigData(),
     multi: true,
   },
-  {provide: FEAT_TOGGLE_TOKEN, useFactory: getEnv, multi: true}
+  {provide: FEAT_TOGGLE_TOKEN, useFactory: getEnv}
 ];
 
 if (environment.SENTRY_DNS) {


### PR DESCRIPTION
I don't know why it worked earlier for me locally. By removing `multi: true` application doesn't wait for array, it just takes an object. And object should be passed.