### PR TITLE
fix(patron-login): initCacheServer&initDID = false

### DIFF
--- a/src/app/routes/ewt-patron/patron-login.service.ts
+++ b/src/app/routes/ewt-patron/patron-login.service.ts
@@ -20,8 +20,8 @@ export class PatronLoginService {
     from(this.iamService.login({
       walletProvider,
       reinitializeMetamask: true,
-      initCacheServer: true,
-      initDid: true
+      initCacheServer: false,
+      initDID: false
     })).subscribe(() => {
         this.iamService.clearWaitSignatureTimer();
         this.store.dispatch(StakeActions.initStakingPool());

--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -39,7 +39,7 @@ export interface LoginOptions {
   walletProvider?: WalletProvider;
   reinitializeMetamask?: boolean;
   initCacheServer?: boolean;
-  initDid?: boolean;
+  initDID?: boolean;
 }
 
 export enum LoginType {


### PR DESCRIPTION
only metamask connection is necessary for patron staking
No signature should be required

rename to `initDID` to match `iam-client-lib`