### PR TITLE
fix enrolment navigation.

### DIFF
--- a/src/app/routes/enrolment/enrolment.component.ts
+++ b/src/app/routes/enrolment/enrolment.component.ts
@@ -62,7 +62,7 @@ export class EnrolmentComponent implements OnInit, AfterViewInit {
             this.initDefault();
           }
         } else if (queryParams.selectedTab) {
-          if (queryParams.selectedTab === 1) {
+          if (queryParams.selectedTab === '1') {
             this.initDefaultMyEnrolments();
           } else {
             this.initDefault();


### PR DESCRIPTION
Problem occurs when trying to navigate from `enrolment requests` to `my enrolments` in `Enrolments` page. Previously it worked because we had loose equality. Now we have strict equality and we are comparing string to number.