### PR TITLE
fix switchboard header logo navigation.

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -3,7 +3,7 @@
   <nav class="navbar topnavbar" role="navigation">
     <!-- START navbar header-->
     <div class="navbar-header" id="navbarHeader">
-      <a href="#/dashboard">
+      <a routerLink="/dashboard">
         <img src="assets/img/logo-ew-switchboard.svg" class="logo-ew"/>
       </a>
     </div>


### PR DESCRIPTION
When clicking on logo, page is reloaded and uses #. This fix will stop refreshing a page and removes # from url.