### PR TITLE
fix: SWTCH-1209 opening dialog for suborganization that do not belong to us

### DIFF
--- a/src/app/routes/applications/applications.component.html
+++ b/src/app/routes/applications/applications.component.html
@@ -14,6 +14,7 @@
             </button>
             <ng-template #subOrg>
               <button mat-raised-button class="btn btn-primary btn-small mb-3 mb-lg-0"
+                      [disabled]="isSelectedOrgNotOwnedByUser$ | async"
                       (click)="createSubOrg()">Create
                 Sub-Organization
               </button>

--- a/src/app/routes/applications/applications.component.ts
+++ b/src/app/routes/applications/applications.component.ts
@@ -27,6 +27,7 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('listRole') listRole: GovernanceListComponent;
 
   hierarchyLength$ = this.store.select(OrganizationSelectors.getHierarchyLength);
+  isSelectedOrgNotOwnedByUser$ = this.store.select(OrganizationSelectors.isSelectedOrgNotOwnedByUser);
 
   isAppShown = false;
   isRoleShown = false;

--- a/src/app/state/organization/organization.selectors.ts
+++ b/src/app/state/organization/organization.selectors.ts
@@ -22,3 +22,8 @@ export const getHierarchyLength = createSelector(
   getHierarchy,
   hierarchy => hierarchy.length
 );
+
+export const isSelectedOrgNotOwnedByUser = createSelector(
+  getLastHierarchyOrg,
+  (organization) => !organization.isOwnedByCurrentUser
+);


### PR DESCRIPTION
Button for creation sub organization was enabled always, even if we were looking on organization which namespace belongs to a different user.