### PR TITLE
fix: unhandled error while trying to initialize iam.

### DIFF
--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -80,10 +80,18 @@ export class LoginService {
           if (loginSuccessful) {
             this.iamListenerService.setListeners((config) => this.openSwal(config, redirectOnChange));
           }
+          if (!loginSuccessful) {
+            this.loadingService.hide();
+            this.openSwal({
+              title: 'Ops!', text: 'Something went wrong :('
+            }, redirectOnChange);
+          }
           return {success: Boolean(loginSuccessful), accountInfo};
         }),
 
-        delayWhen(({ success }) => { if (success) return this.storeSession() }),
+        delayWhen(({success}) => {
+          if (success) return this.storeSession();
+        }),
         catchError(err => this.handleLoginErrors(err, redirectOnChange))
       );
   }


### PR DESCRIPTION
The error occurs while trying to initialize iam, but error was thrown. Iam service is catching that error while calling `initializeConnection` method and do not rethrow that. With having that, there is no information for the user that something went wrong and user is able to click through application.