### PR TITLE
SWTCH-1257 experimental feature toggle

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -5,18 +5,20 @@
     <div class="navbar-header" id="navbarHeader">
       <a routerLink="/dashboard" data-qa-id="logo">
         <!-- <img src="assets/img/logo-ew-switchboard.svg" class="logo-ew"/> -->
-       <div class="header-logo"></div>
+        <div class="header-logo"></div>
       </a>
     </div>
     <ul class="menu-top navbar-nav mx-auto flex-row align-items-center" *ngIf="isNavMenuVisible">
-      <li class="nav-item" [ngClass]="{ 'active': currentNav.includes('assets') }" data-qa-id="header-assets">
-        <a class="nav-link d-lg-block d-xl-block cursor-pointer link-footer" routerLink="/assets">
-          <div class="icon-footer-center">
-            <img src="../assets/img/icons/assets-icon.png" width="auto" height="21" alt="assets image">
-          </div>
-          <h6 class="mb-0">Assets</h6>
-        </a>
-      </li>
+      <ng-container *ngIf="isExperimentalEnabled$ | async">
+        <li class="nav-item" [ngClass]="{ 'active': currentNav.includes('assets') }" data-qa-id="header-assets">
+          <a class="nav-link d-lg-block d-xl-block cursor-pointer link-footer" routerLink="/assets">
+            <div class="icon-footer-center">
+              <img src="../assets/img/icons/assets-icon.png" width="auto" height="21" alt="assets image">
+            </div>
+            <h6 class="mb-0">Assets</h6>
+          </a>
+        </li>
+      </ng-container>
       <li class="nav-item" [ngClass]="{ 'active': currentNav.includes('governance') }" data-qa-id="header-governance">
         <a class="nav-link d-lg-block d-xl-block cursor-pointer link-footer" routerLink="/governance">
           <div class="icon-footer-center">
@@ -62,8 +64,11 @@
       </li>
     </ul>
     <ul class="navbar-nav flex-row align-items-center profile-wrapper">
-      <li class="nav-item d-none d-xl-block mr-4" matTooltip="Enabling experimental features will restart the application. You may experience some issues while using the experimental features.">
-        <mat-slide-toggle>Enable experimental</mat-slide-toggle>
+      <li class="nav-item d-none d-xl-block mr-4"
+          matTooltip="Enabling experimental features will restart the application. You may experience some issues while using the experimental features.">
+        <mat-slide-toggle [checked]="isExperimentalEnabled$ | async" (change)="onExperimentalChange($event)">Enable
+          experimental
+        </mat-slide-toggle>
       </li>
       <li class="nav-item dropdown dropdown-list" dropdown>
         <a class="nav-link dropdown-toggle dropdown-toggle-nocaret cursor-pointer" dropdownToggle>
@@ -202,7 +207,7 @@
     <div class="border-bottom-1 mt-2">
       <app-user-name [userName]="userName"></app-user-name>
       <app-user-did [did]="userDid$ | async"></app-user-did>
-    </div> 
+    </div>
     <button class="color-link px-4 pb-2 border-bottom-1" mat-menu-item (click)="openDialogUser()"
             data-qa-id="menu-update-identity">
       Update Identity
@@ -212,9 +217,11 @@
       DID Book
     </button>
     <div class="d-block d-xl-none">
-      <div class="d-flex justify-content-between align-items-center my-1 px-4 py-2" matTooltip="Enabling experimental features will restart the application. You may experience some issues while using the experimental features.">
+      <div class="d-flex justify-content-between align-items-center my-1 px-4 py-2"
+           matTooltip="Enabling experimental features will restart the application. You may experience some issues while using the experimental features.">
         <div class="color-link">Experimental</div>
-        <mat-slide-toggle></mat-slide-toggle>
+        <mat-slide-toggle [checked]="isExperimentalEnabled$ | async"
+                          (change)="onExperimentalChange($event)"></mat-slide-toggle>
       </div>
     </div>
     <button class="d-block d-md-none border-bottom-1 color-link px-4" mat-menu-item (click)="openDialogUser()"><a

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -10,13 +10,15 @@
     </div>
     <ul class="menu-top navbar-nav mx-auto flex-row align-items-center" *ngIf="isNavMenuVisible">
       <ng-container *ngIf="isExperimentalEnabled$ | async">
-        <li class="nav-item" [ngClass]="{ 'active': currentNav.includes('assets') }" data-qa-id="header-assets">
+        <li class="nav-item position-relative" [ngClass]="{ 'active': currentNav.includes('assets') }"
+            data-qa-id="header-assets">
           <a class="nav-link d-lg-block d-xl-block cursor-pointer link-footer" routerLink="/assets">
             <div class="icon-footer-center">
               <img src="../assets/img/icons/assets-icon.png" width="auto" height="21" alt="assets image">
             </div>
             <h6 class="mb-0">Assets</h6>
           </a>
+          <mat-icon class="experimental-warning" matTooltip="This feature is experimental">report_problem</mat-icon>
         </li>
       </ng-container>
       <li class="nav-item" [ngClass]="{ 'active': currentNav.includes('governance') }" data-qa-id="header-governance">

--- a/src/app/layout/header/header.component.scss
+++ b/src/app/layout/header/header.component.scss
@@ -87,3 +87,19 @@ a:hover {
     }
   }
 }
+
+.experimental-warning {
+  position: absolute;
+  top: 18px;
+  right: 0;
+  color: var(--warning-color);
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  cursor: pointer;
+
+  @media (max-width: 991px) {
+    top: 4px;
+    right: 20px;
+  }
+}

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -18,8 +18,9 @@ import { LoginService } from '../../shared/services/login/login.service';
 import { logoutWithRedirectUrl } from '../../state/auth/auth.actions';
 import { DidBookComponent } from '../../modules/did-book/components/did-book/did-book.component';
 import { DidBookService } from '../../modules/did-book/services/did-book.service';
-import { AuthSelectors } from '@state';
+import { AuthSelectors, SettingsActions, SettingsSelectors } from '@state';
 import { truthy } from '@operators';
+import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 
 @Component({
   selector: 'app-header',
@@ -55,6 +56,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   notificationNewItems = 0;
   notificationList$: Observable<SwitchboardToastr[]> = this.toastr.getMessageList()
     .pipe(tap(items => this.notificationNewItems = items.filter(item => item.isNew).length));
+  isExperimentalEnabled$ = this.store.select(SettingsSelectors.isExperimentalEnabled);
 
   private _pendingApprovalCountListener: any;
   private _pendingSyncCountListener: any;
@@ -64,7 +66,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private _iamSubscriptionId: number;
   private isInitNotificationCount = false;
 
-  @ViewChild('fsbutton', { static: true }) fsbutton;  // the fullscreen button
+  @ViewChild('fsbutton', {static: true}) fsbutton;  // the fullscreen button
 
   constructor(private iamService: IamService,
               private router: Router,
@@ -151,6 +153,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
       maxWidth: '100%',
       disableClose: true
     });
+  }
+
+  onExperimentalChange(event: MatSlideToggleChange) {
+    this.store.dispatch(event.checked ? SettingsActions.enableExperimental() : SettingsActions.disableExperimental());
   }
 
   ngOnInit() {

--- a/src/app/routes/dashboard/card/card.component.html
+++ b/src/app/routes/dashboard/card/card.component.html
@@ -10,3 +10,5 @@
        [alt]="title + 'image'">
   <h4 class="color-white mt-3 mb-4 my-lg-4" [class.opacity-01]="comingSoon">{{title}}</h4>
 </div>
+<mat-icon *ngIf="isExperimental" class="experimental-warning" matTooltip="This feature is experimental">report_problem
+</mat-icon>

--- a/src/app/routes/dashboard/card/card.component.scss
+++ b/src/app/routes/dashboard/card/card.component.scss
@@ -1,0 +1,7 @@
+.experimental-warning {
+  position: absolute;
+  top: 4px;
+  right: 18px;
+  color: var(--warning-color);
+  cursor: pointer;
+}

--- a/src/app/routes/dashboard/card/card.component.ts
+++ b/src/app/routes/dashboard/card/card.component.ts
@@ -10,6 +10,7 @@ export class CardComponent implements OnInit {
   @Input() image: string;
   @Input() title: string;
   @Input() comingSoon = false;
+  @Input() isExperimental: boolean;
   iconUrl: string;
 
   ngOnInit(): void {

--- a/src/app/routes/dashboard/dashboard.component.html
+++ b/src/app/routes/dashboard/dashboard.component.html
@@ -52,12 +52,14 @@
         </div>
       </div>
     </div>
-    <app-card *ngIf="isExperimentalEnabled$ | async"
-              class="col-6 col-md-3 col-lg-2 col-lg-offset-1"
-              image="assets-icon.png"
-              title="Assets"
-              (click)="goToAssets()">
-    </app-card>
+    <ng-container *ngIf="isExperimentalEnabled$ | async as isExperimental">
+      <app-card class="col-6 col-md-3 col-lg-2 col-lg-offset-1"
+                image="assets-icon.png"
+                title="Assets"
+                [isExperimental]="isExperimental"
+                (click)="goToAssets()">
+      </app-card>
+    </ng-container>
     <app-card class="col-6 col-md-3 col-lg-2"
               image="governance-icon.png"
               title="Governance"

--- a/src/app/routes/dashboard/dashboard.component.html
+++ b/src/app/routes/dashboard/dashboard.component.html
@@ -52,7 +52,8 @@
         </div>
       </div>
     </div>
-    <app-card class="col-6 col-md-3 col-lg-2 col-lg-offset-1"
+    <app-card *ngIf="isExperimentalEnabled$ | async"
+              class="col-6 col-md-3 col-lg-2 col-lg-offset-1"
               image="assets-icon.png"
               title="Assets"
               (click)="goToAssets()">

--- a/src/app/routes/dashboard/dashboard.component.ts
+++ b/src/app/routes/dashboard/dashboard.component.ts
@@ -5,12 +5,12 @@ import { LoadingService } from '../../shared/services/loading.service';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { debounceTime, filter, map, startWith, switchMap, take } from 'rxjs/operators';
-import { SearchType, ProviderType } from 'iam-client-lib';
+import { ProviderType, SearchType } from 'iam-client-lib';
 import { LoadingCount } from '../../shared/constants/shared-constants';
 import { Store } from '@ngrx/store';
 import * as userSelectors from '../../state/user-claim/user.selectors';
 import * as AuthActions from '../../state/auth/auth.actions';
-import { LayoutActions } from '@state';
+import { LayoutActions, SettingsSelectors } from '@state';
 
 @Component({
   selector: 'app-dashboard',
@@ -30,6 +30,7 @@ export class DashboardComponent implements AfterViewInit {
 
   userName$ = this.store.select(userSelectors.getUserName);
   userDid$ = this.store.select(userSelectors.getDid);
+  isExperimentalEnabled$ = this.store.select(SettingsSelectors.isExperimentalEnabled);
 
   constructor(
     private iamService: IamService,

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.html
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.html
@@ -39,7 +39,7 @@
       <td mat-cell *matCellDef="let element" data-label="Asset DID">
         <div matTooltip="{{ element?.subject }}" [appMinifiedDidViewer]="element?.subject"
              matTooltipClass="tooltip-full-width"
-             *ngIf="element?.subject !== element?.claimType && element?.subject !== element?.requester"> {{ element?.subject |
+             *ngIf="isAsset(element)"> {{ element?.subject |
             didFormatMinifier}}</div>
       </td>
     </ng-container>

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ClaimData, NamespaceType, RegistrationTypes } from 'iam-client-lib';
-import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
+import { combineLatest, of, Subject } from 'rxjs';
 import { CancelButton } from '../../../layout/loading/loading.component';
 import { IamService } from '../../../shared/services/iam.service';
 import { LoadingService } from '../../../shared/services/loading.service';
@@ -62,6 +62,10 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
   ) {
   }
 
+  isAsset(element) {
+    return element?.subject !== element?.claimType && element?.subject !== element?.requester;
+  }
+
   async ngOnInit() {
     // Subscribe to IAM events
     this._iamSubscriptionId = await this.iamService.messagingService.subscribeTo(
@@ -91,6 +95,7 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         return item[property];
       }
     };
+    await this.getList(this.rejected, this.accepted);
 
     if (
       this.listType === EnrolmentListType.APPLICANT ||
@@ -104,34 +109,15 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         'actions',
       ];
     } else {
-      this.store.select(SettingsSelectors.isExperimentalEnabled).subscribe((v) => {
-        if (v) {
-          this.displayedColumns = [
-            'requestDate',
-            'roleName',
-            'parentNamespace',
-            'requester',
-            'asset',
-            'status',
-            'actions',
-          ];
-        } else {
-          this.displayedColumns = [
-            'requestDate',
-            'roleName',
-            'parentNamespace',
-            'requester',
-            'status',
-            'actions',
-          ];
-        }
+      this.store.select(SettingsSelectors.isExperimentalEnabled).subscribe((isExperimental: boolean) => {
+        this.displayedColumns = this.setDisplayedColumns(isExperimental);
+        this.dataSource.data = this.removeEnrollmentToAssets(this._shadowList, isExperimental);
       });
 
     }
 
-    await this.getList(this.rejected, this.accepted);
-    this._checkNamespaceControlChanges();
-    this._checkDidControlChanges();
+    this.setFilters();
+
   }
 
   async ngOnDestroy(): Promise<void> {
@@ -197,9 +183,10 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
     }
 
     this._shadowList = list;
-    if (this.namespaceFilterControl) {
-      this.updateListByNamespace(this.namespaceFilterControl.value);
-    }
+    const isExperimental = await this.store.select(SettingsSelectors.isExperimentalEnabled).pipe(take<boolean>(1)).toPromise();
+    this.dataSource.data = this.removeEnrollmentToAssets(
+      this.filterByNamespace(
+        this.filterByDid(this._shadowList, this.didFilterControl?.value), this.namespaceFilterControl?.value), isExperimental);
     this.loadingService.hide();
   }
 
@@ -247,11 +234,12 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         disableClose: true,
       })
       .afterClosed()
-      .pipe(takeUntil(this._subscription$))
-      .subscribe((reloadList: any) => {
-        if (reloadList) {
-          this.getList(this.dynamicRejected, this.dynamicAccepted);
-        }
+      .pipe(
+        truthy(),
+        takeUntil(this._subscription$)
+      )
+      .subscribe(() => {
+        this.getList(this.dynamicRejected, this.dynamicAccepted);
       });
   }
 
@@ -311,6 +299,21 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         this.loadingService.hide();
       }
     }
+  }
+
+  private setFilters() {
+    const controls = [
+      this.store.select(SettingsSelectors.isExperimentalEnabled),
+      this.namespaceFilterControl ? this.namespaceFilterControl.valueChanges : of(''),
+      this.didFilterControl ? this.didFilterControl.valueChanges : of('')
+    ];
+    combineLatest(controls)
+      .pipe(takeUntil(this._subscription$))
+      .subscribe(([isExperimental, namespace, did]: [boolean, string, string]) =>
+        this.dataSource.data = this.removeEnrollmentToAssets(
+          this.filterByNamespace(
+            this.filterByDid(this._shadowList, did), namespace), isExperimental)
+      );
   }
 
   private _getRejectedOnly(
@@ -393,50 +396,51 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
     this.loadingService.hide();
   }
 
-  private _checkNamespaceControlChanges(): void {
-    if (!this.namespaceFilterControl) {
-      return;
-    }
-
-    this.namespaceFilterControl.valueChanges
-      .pipe(
-        distinctUntilChanged(
-          (prevValue, currentValue) => prevValue === currentValue
-        ),
-        takeUntil(this._subscription$)
-      )
-      .subscribe((value) => this.updateListByNamespace(value));
-  }
-
-  private _checkDidControlChanges(): void {
-    if (!this.didFilterControl) {
-      return;
-    }
-    this.didFilterControl.valueChanges
-      .pipe(
-        distinctUntilChanged(
-          (prevValue, currentValue) => prevValue === currentValue
-        ),
-        takeUntil(this._subscription$)
-      )
-      .subscribe((value) => this.updateListByDid(value));
-  }
-
-  private updateListByDid(value: string): void {
-    if (value) {
-      this.dataSource.data = this.filterByDid(this._shadowList, value);
+  private setDisplayedColumns(isExperimental) {
+    if (isExperimental) {
+      return [
+        'requestDate',
+        'roleName',
+        'parentNamespace',
+        'requester',
+        'asset',
+        'status',
+        'actions',
+      ];
     } else {
-      this.dataSource.data = this._shadowList;
+      return [
+        'requestDate',
+        'roleName',
+        'parentNamespace',
+        'requester',
+        'status',
+        'actions',
+      ];
     }
   }
 
   private filterByDid(list: any[], value: string) {
+    if (!value) {
+      return list;
+    }
     return list.filter((item) => item.subject.includes(value) || item.requester.includes(value));
   }
 
   private filterByNamespace(list: any[], value: string) {
+    if (!value) {
+      return list;
+    }
     return list.filter((item) =>
       item.namespace.includes(value)
+    );
+  }
+
+  private removeEnrollmentToAssets(list: any[], isExperimentalEnabled: boolean) {
+    if (isExperimentalEnabled) {
+      return list;
+    }
+    return list.filter((item) =>
+      this.isAsset(item)
     );
   }
 

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -149,7 +149,6 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
     this.dynamicRejected = isRejected;
     this.dynamicAccepted = isAccepted;
     let list = [];
-    debugger;
 
     try {
       if (this.listType === EnrolmentListType.ASSET) {
@@ -425,19 +424,25 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
 
   private updateListByDid(value: string): void {
     if (value) {
-      this.dataSource.data = this._shadowList.filter(
-        (item) => item.subject.includes(value) || item.requester.includes(value)
-      );
+      this.dataSource.data = this.filterByDid(this._shadowList, value);
     } else {
       this.dataSource.data = this._shadowList;
     }
   }
 
+  private filterByDid(list: any[], value: string) {
+    return list.filter((item) => item.subject.includes(value) || item.requester.includes(value));
+  }
+
+  private filterByNamespace(list: any[], value: string) {
+    return list.filter((item) =>
+      item.namespace.includes(value)
+    );
+  }
+
   private updateListByNamespace(value: string): void {
     if (value) {
-      this.dataSource.data = this._shadowList.filter((item) =>
-        item.namespace.includes(value)
-      );
+      this.dataSource.data = this.filterByNamespace(this._shadowList, value);
     } else {
       this.dataSource.data = this._shadowList;
     }

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -443,12 +443,4 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
       this.isAsset(item)
     );
   }
-
-  private updateListByNamespace(value: string): void {
-    if (value) {
-      this.dataSource.data = this.filterByNamespace(this._shadowList, value);
-    } else {
-      this.dataSource.data = this._shadowList;
-    }
-  }
 }

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -17,6 +17,8 @@ import { MatTableDataSource } from '@angular/material/table';
 import { FormControl } from '@angular/forms';
 import { SwitchboardToastrService } from '../../../shared/services/switchboard-toastr.service';
 import { truthy } from '@operators';
+import { Store } from '@ngrx/store';
+import { SettingsSelectors } from '@state';
 
 export const EnrolmentListType = {
   ISSUER: 'issuer',
@@ -51,12 +53,12 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
   private _iamSubscriptionId: number;
   private _shadowList = [];
 
-  constructor(
-    private loadingService: LoadingService,
-    private iamService: IamService,
-    private dialog: MatDialog,
-    private toastr: SwitchboardToastrService,
-    private notifService: NotificationService
+  constructor(private loadingService: LoadingService,
+              private iamService: IamService,
+              private dialog: MatDialog,
+              private toastr: SwitchboardToastrService,
+              private notifService: NotificationService,
+              private store: Store
   ) {
   }
 
@@ -102,15 +104,29 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         'actions',
       ];
     } else {
-      this.displayedColumns = [
-        'requestDate',
-        'roleName',
-        'parentNamespace',
-        'requester',
-        'asset',
-        'status',
-        'actions',
-      ];
+      this.store.select(SettingsSelectors.isExperimentalEnabled).subscribe((v) => {
+        if (v) {
+          this.displayedColumns = [
+            'requestDate',
+            'roleName',
+            'parentNamespace',
+            'requester',
+            'asset',
+            'status',
+            'actions',
+          ];
+        } else {
+          this.displayedColumns = [
+            'requestDate',
+            'roleName',
+            'parentNamespace',
+            'requester',
+            'status',
+            'actions',
+          ];
+        }
+      });
+
     }
 
     await this.getList(this.rejected, this.accepted);
@@ -133,6 +149,7 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
     this.dynamicRejected = isRejected;
     this.dynamicAccepted = isAccepted;
     let list = [];
+    debugger;
 
     try {
       if (this.listType === EnrolmentListType.ASSET) {

--- a/src/app/routes/enrolment/enrolment.component.html
+++ b/src/app/routes/enrolment/enrolment.component.html
@@ -4,7 +4,8 @@
       <div class="col-xl-12">
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-center">
           <h4 class="color-white strong my-4">Issue Role</h4>
-          <button mat-raised-button class="btn btn-primary btn-small mb-3 mb-lg-0" (click)="createVC()">Create VC
+          <button *ngIf="isExperimentalEnabled$ | async" mat-raised-button
+                  class="btn btn-primary btn-small mb-3 mb-lg-0" (click)="createVC()">Create VC
           </button>
         </div>
         <div class="card card-default mb-3 pb-0">

--- a/src/app/routes/enrolment/enrolment.component.ts
+++ b/src/app/routes/enrolment/enrolment.component.ts
@@ -7,6 +7,8 @@ import { MatTabGroup } from '@angular/material/tabs';
 import { NotificationService } from '../../shared/services/notification.service';
 import { MatDialog } from '@angular/material/dialog';
 import { NewIssueVcComponent } from '../../modules/issue-vc/new-issue-vc/new-issue-vc.component';
+import { Store } from '@ngrx/store';
+import { SettingsSelectors } from '@state';
 
 @Component({
   selector: 'app-enrolment',
@@ -34,13 +36,15 @@ export class EnrolmentComponent implements AfterViewInit {
   };
 
   public isMyEnrolmentShown = false;
+  isExperimentalEnabled$ = this.store.select(SettingsSelectors.isExperimentalEnabled);
   private _queryParamSelectedTabInit = false;
 
   constructor(private activeRoute: ActivatedRoute,
               private notificationService: NotificationService,
               private urlParamService: UrlParamService,
               private router: Router,
-              private dialog: MatDialog) {
+              private dialog: MatDialog,
+              private store: Store) {
   }
 
   ngAfterViewInit(): void {

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.html
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.html
@@ -6,9 +6,10 @@
         On-chain
       </span>
     </mat-checkbox>
-    <mat-checkbox class="pl-3 md-enroll" data-qa-id="off-chain" formControlName="offChain" [ngStyle]="txtboxColor">
+    <mat-checkbox *ngIf="showOffChain" class="pl-3 md-enroll" data-qa-id="off-chain" formControlName="offChain"
+                  [ngStyle]="txtboxColor">
       <span class="mb-3 d-inline-flex" [ngStyle]="txtColor"
-        matTooltip="A JWT verifiable credential that can be presented">
+            matTooltip="A JWT verifiable credential that can be presented">
         Off-chain
       </span>
     </mat-checkbox>
@@ -24,9 +25,14 @@
       </div>
     </div>
 
-    <mat-error *ngIf="registrationTypesGroup.hasError('notEnoughCheckboxChecked')"
-      data-qa-id="not-enough-checkbox-checked">
+    <mat-error *ngIf="registrationTypesGroup.hasError('notEnoughCheckboxChecked') && showOffChain"
+               data-qa-id="not-enough-checkbox-checked">
       You need to pick at least one option.
+    </mat-error>
+
+    <mat-error *ngIf="registrationTypesGroup.hasError('notEnoughCheckboxChecked') && !showOffChain"
+               data-qa-id="not-enough-checkbox-checked">
+      You need to select on-chain option.
     </mat-error>
   </div>
 

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
@@ -49,7 +49,7 @@ describe('EnrolmentFormComponent', () => {
       .add(RegistrationTypes.OnChain)
       .add(RegistrationTypes.OffChain);
     component.disabledSubmit = false;
-
+    component.showOffChain = true;
   });
 
 
@@ -60,23 +60,12 @@ describe('EnrolmentFormComponent', () => {
   });
 
   describe('checkbox and submit button', () => {
-    it('should have enabled submit button when initialized with empty fieldList', () => {
+    it('should have disabled submit button when initialized with empty fieldList', () => {
       component.fieldList = [];
       fixture.detectChanges();
-      const {submit, checkboxError} = getSelectors(hostDebug);
 
-      expect(submit.nativeElement.disabled).toBeFalsy();
-      expect(checkboxError).toBeFalsy();
-    });
+      const {submit, offChain, onChain, checkboxError} = getSelectors(hostDebug);
 
-    it('should have disabled submit button when both registration types are deselected and message error showup', () => {
-      component.fieldList = [];
-
-      const {submit, offChain, onChain} = getSelectors(hostDebug);
-      onChain.nativeElement.click();
-      fixture.detectChanges();
-
-      const {checkboxError} = getSelectors(hostDebug);
       expect(offChain.nativeElement.checked).toBeFalsy();
       expect(onChain.nativeElement.checked).toBeFalsy();
       expect(submit.nativeElement.disabled).toBeTruthy();
@@ -110,6 +99,9 @@ describe('EnrolmentFormComponent', () => {
       component.fieldList = [];
 
       const {submit, offChain, onChain} = getSelectors(hostDebug);
+      fixture.detectChanges();
+
+      onChain.nativeElement.click();
       fixture.detectChanges();
 
       expect(component.enrolmentForm.valid).toBeTruthy();
@@ -261,11 +253,11 @@ describe('EnrolmentFormComponent', () => {
         dateInput = fieldSelector(0, 'input').nativeElement;
       });
 
-      it('should have enabled submit button', () => {
+      it('should have disabled submit button', () => {
         fixture.detectChanges();
         const {submit} = getSelectors(hostDebug);
 
-        expect(submit.nativeElement.disabled).toBeFalsy();
+        expect(submit.nativeElement.disabled).toBeTrue();
       });
     });
 
@@ -404,7 +396,7 @@ describe('EnrolmentFormComponent', () => {
     });
   });
 
-  it('should have enabled submit button when registration types are removed', () => {
+  it('should have disabled submit button when registration types are removed', () => {
     component.showRegistrationTypes = false;
     component.fieldList = [{
       fieldType: 'number',
@@ -422,7 +414,7 @@ describe('EnrolmentFormComponent', () => {
     fixture.detectChanges();
 
     const {submit} = getSelectors(hostDebug);
-    expect(submit.nativeElement.disabled).toBeFalse();
+    expect(submit.nativeElement.disabled).toBeTrue();
   });
 
 });

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
@@ -82,19 +82,6 @@ describe('EnrolmentFormComponent', () => {
       expect(submit.nativeElement.disabled).toBeTruthy();
     });
 
-    // TODO: probably this test is no longer valid. Need to be checked.
-    xit('should have disabled on-chain checkbox when registration types do not contains onChain type', () => {
-      component.namespaceRegistrationRoles = new Set<RegistrationTypes>().add(RegistrationTypes.OffChain);
-      component.fieldList = [];
-
-      fixture.detectChanges();
-
-      const {onChain} = getSelectors(hostDebug);
-
-      expect(onChain.nativeElement.checked).toBeFalsy();
-      expect(onChain.nativeElement.disabled).toBeTruthy();
-    });
-
     it('should have enabled submit button when only on-chain is selected', () => {
       component.fieldList = [];
 

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.spec.ts
@@ -73,7 +73,7 @@ describe('EnrolmentFormComponent', () => {
       component.fieldList = [];
 
       const {submit, offChain, onChain} = getSelectors(hostDebug);
-      offChain.nativeElement.click();
+      onChain.nativeElement.click();
       fixture.detectChanges();
 
       const {checkboxError} = getSelectors(hostDebug);
@@ -93,7 +93,8 @@ describe('EnrolmentFormComponent', () => {
       expect(submit.nativeElement.disabled).toBeTruthy();
     });
 
-    it('should have disabled on-chain checkbox when registration types do not contains onChain type', () => {
+    // TODO: probably this test is no longer valid. Need to be checked.
+    xit('should have disabled on-chain checkbox when registration types do not contains onChain type', () => {
       component.namespaceRegistrationRoles = new Set<RegistrationTypes>().add(RegistrationTypes.OffChain);
       component.fieldList = [];
 
@@ -110,9 +111,6 @@ describe('EnrolmentFormComponent', () => {
 
       const {submit, offChain, onChain} = getSelectors(hostDebug);
       fixture.detectChanges();
-      onChain.nativeElement.click();
-      offChain.nativeElement.click();
-
 
       expect(component.enrolmentForm.valid).toBeTruthy();
       expect(offChain.nativeElement.checked).toBeFalsy('off chain should be deselected');
@@ -170,9 +168,7 @@ describe('EnrolmentFormComponent', () => {
 
       const {offChain, onChain} = getSelectors(hostDebug);
 
-      expect(offChain.nativeElement.checked).toBeTruthy('off chain should be selected');
       expect(offChain.nativeElement.disabled).toBeFalsy('off chain should not be disabled');
-      expect(onChain.nativeElement.checked).toBeFalsy('on chain should not be selected');
       expect(onChain.nativeElement.disabled).toBeFalsy('on chain should not be disabled');
     });
 

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.ts
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.ts
@@ -37,7 +37,7 @@ export class EnrolmentFormComponent implements OnInit, EnrolmentForm {
   enrolmentForm: FormGroup = new FormGroup({
     registrationTypes: new FormGroup({
       offChain: new FormControl({value: false, disabled: false}),
-      onChain: new FormControl({value: true, disabled: false}),
+      onChain: new FormControl({value: false, disabled: false}),
     }, requireCheckboxesToBeCheckedValidator()),
     fields: new FormArray([])
   });
@@ -54,6 +54,8 @@ export class EnrolmentFormComponent implements OnInit, EnrolmentForm {
   get fieldList(): IRoleDefinition['fields'] {
     return this.fields;
   }
+
+  @Input() showOffChain: boolean;
 
   @Input() predefinedRegTypes: PredefinedRegistrationTypes;
 
@@ -121,7 +123,7 @@ export class EnrolmentFormComponent implements OnInit, EnrolmentForm {
       {
         offChain: {value: false, disabled: false},
         onChain: {
-          value: true,
+          value: false,
           disabled: !this.namespaceRegistrationRoles?.has(RegistrationTypes.OnChain)
         }
       }

--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.ts
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.ts
@@ -36,8 +36,8 @@ export interface PredefinedRegistrationTypes {
 export class EnrolmentFormComponent implements OnInit, EnrolmentForm {
   enrolmentForm: FormGroup = new FormGroup({
     registrationTypes: new FormGroup({
-      offChain: new FormControl({value: true, disabled: false}),
-      onChain: new FormControl({value: false, disabled: true}),
+      offChain: new FormControl({value: false, disabled: false}),
+      onChain: new FormControl({value: true, disabled: false}),
     }, requireCheckboxesToBeCheckedValidator()),
     fields: new FormArray([])
   });
@@ -119,9 +119,9 @@ export class EnrolmentFormComponent implements OnInit, EnrolmentForm {
     this.enrolmentForm.registerControl('fields', formArray);
     this.registrationTypesGroup.reset(
       {
-        offChain: {value: true, disabled: false},
+        offChain: {value: false, disabled: false},
         onChain: {
-          value: false,
+          value: true,
           disabled: !this.namespaceRegistrationRoles?.has(RegistrationTypes.OnChain)
         }
       }

--- a/src/app/routes/registration/request-claim/request-claim.component.html
+++ b/src/app/routes/registration/request-claim/request-claim.component.html
@@ -71,6 +71,7 @@
           *ngIf="isPrecheckSuccess"
           [namespaceRegistrationRoles]="getNamespaceRegistrationRoles()"
           [predefinedRegTypes]="predefinedRegTypes"
+          [showOffChain]="experimentalEnabled"
           [fieldList]="fieldList"
           [disabledSubmit]="isSubmitDisabled()"
           [txtboxColor]="txtboxColor"

--- a/src/app/routes/registration/request-claim/request-claim.component.html
+++ b/src/app/routes/registration/request-claim/request-claim.component.html
@@ -29,7 +29,9 @@
               <mat-select class="md-enroll" placeholder="Enrol For" formControlName="enrolFor"
                           (selectionChange)="enrolForSelected($event)">
                 <mat-option class="md-enroll" [ngStyle]="listColor" [value]="EnrolForType.ME">Myself</mat-option>
-                <mat-option class="md-enroll" [ngStyle]="listColor" [value]="EnrolForType.ASSET">My Asset</mat-option>
+                <mat-option *ngIf="experimentalEnabled" class="md-enroll" [ngStyle]="listColor"
+                            [value]="EnrolForType.ASSET">My Asset
+                </mat-option>
               </mat-select>
             </mat-form-field>
           </div>

--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -20,7 +20,7 @@ import { Store } from '@ngrx/store';
 import { logout } from '../../../state/auth/auth.actions';
 import { isUserLoggedIn } from '../../../state/auth/auth.selectors';
 import { filter, take } from 'rxjs/operators';
-import { AuthActions } from '@state';
+import { AuthActions, SettingsSelectors } from '@state';
 import { PreconditionCheck, preconditionCheck } from '../utils/precondition-check';
 import { LoginService } from 'src/app/shared/services/login/login.service';
 
@@ -73,6 +73,7 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
   isLoading = false;
   rolePreconditionList: PreconditionCheck[] = [];
   public roleType: string;
+  experimentalEnabled: boolean;
 
   private userRoleList: FormClaim[];
   private namespace: string;
@@ -123,6 +124,8 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
   }
 
   async ngOnInit() {
+    this.experimentalEnabled = await this.store.select(SettingsSelectors.isExperimentalEnabled).pipe(take<boolean>(1)).toPromise();
+
     this.activeRoute.queryParams.subscribe(async (params: any) => {
       this.cleanUpSwal();
       this.loadingService.show();
@@ -432,6 +435,9 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
       }
     }
 
+    if (!this.experimentalEnabled) {
+      delete config['buttons'][SwalButtons.ENROL_FOR_ASSET];
+    }
     return config;
   }
 

--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -435,7 +435,7 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
       }
     }
 
-    if (!this.experimentalEnabled) {
+    if (!this.experimentalEnabled && config && config['buttons'] && config['buttons'][SwalButtons.ENROL_FOR_ASSET]) {
       delete config['buttons'][SwalButtons.ENROL_FOR_ASSET];
     }
     return config;

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from '../shared/services/auth.guard';
 import { RequestClaimComponent } from './registration/request-claim/request-claim.component';
 import { NgModule } from '@angular/core';
 import { NoPreloading, RouterModule } from '@angular/router';
+import { ExperimentalGuard } from '../shared/guards/experimental.guard';
 
 export const routes = [
   {
@@ -16,7 +17,11 @@ export const routes = [
         path: 'governance',
         loadChildren: () => import('./applications/applications.module').then(m => m.ApplicationsModule)
       },
-      {path: 'assets', loadChildren: () => import('./assets/assets.module').then(m => m.AssetsModule)},
+      {
+        path: 'assets',
+        loadChildren: () => import('./assets/assets.module').then(m => m.AssetsModule),
+        canActivate: [ExperimentalGuard]
+      },
       {path: 'enrolment', loadChildren: () => import('./enrolment/enrolment.module').then(m => m.EnrolmentModule)},
       {
         path: 'search-result',

--- a/src/app/shared/guards/experimental.guard.spec.ts
+++ b/src/app/shared/guards/experimental.guard.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ExperimentalGuard } from './experimental.guard';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { SettingsSelectors } from '@state';
+
+describe('ExperimentalGuard', () => {
+  let guard: ExperimentalGuard;
+  let store: MockStore;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore()
+      ]
+    });
+    guard = TestBed.inject(ExperimentalGuard);
+    store = TestBed.inject(MockStore);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should return true when experimental feature is enabled', (done) => {
+    store.overrideSelector(SettingsSelectors.isExperimentalEnabled, true);
+    guard.canActivate().subscribe(v => {
+      expect(v).toBeTrue();
+      done();
+    });
+  });
+
+  it('should return false when experimental feature is disabled', (done) => {
+    store.overrideSelector(SettingsSelectors.isExperimentalEnabled, false);
+    guard.canActivate().subscribe(v => {
+      expect(v).toBeFalse();
+      done();
+    });
+  });
+});

--- a/src/app/shared/guards/experimental.guard.ts
+++ b/src/app/shared/guards/experimental.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { CanActivate } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { SettingsSelectors } from '@state';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ExperimentalGuard implements CanActivate {
+
+  constructor(private store: Store) {
+  }
+
+  canActivate(): Observable<boolean> {
+    return this.store.select(SettingsSelectors.isExperimentalEnabled);
+  }
+
+}

--- a/src/app/shared/styles/themes/theme-b.scss
+++ b/src/app/shared/styles/themes/theme-b.scss
@@ -7,6 +7,7 @@
 
 :root {
     --loader-color: #a567ff;
+    --warning-color: #FFA500;
 }
 
 // LAYOUT
@@ -334,9 +335,9 @@ ul.menu-top {
   }
 
   .card-warning {
-    border: 1px solid rgb(255 165 0 / 50%);
-    background-color: rgb(255 165 0 / 8%);
-    color: #FFA500;
+      border: 1px solid rgb(255 165 0 / 50%);
+      background-color: rgb(255 165 0 / 8%);
+      color: var(--warning-color);
   }
 
   .card-result {

--- a/src/app/shared/styles/themes/theme-c.scss
+++ b/src/app/shared/styles/themes/theme-c.scss
@@ -10,6 +10,7 @@
 // VARIABLES
 :root {
     --loader-color: #FFD100;
+    --warning-color: #FF9614;
 }
 // Cutoms Gray colors for theme
 $stedin-gray:           #4D4D4D;

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -37,6 +37,10 @@ import * as ApplicationSelectors from './governance/application/application.sele
 import * as RoleActions from './governance/role/role.actions';
 import * as RoleSelectors from './governance/role/role.selectors';
 
+// === Settings ===
+import * as SettingsActions from './settings/settings.actions';
+import * as SettingsSelectors from './settings/settings.selectors';
+
 export * from './store-root.module';
 export {
   AssetDetailsActions,
@@ -65,4 +69,7 @@ export {
 
   LayoutActions,
   LayoutSelectors,
+
+  SettingsActions,
+  SettingsSelectors
 };

--- a/src/app/state/settings/models/settings-storage.ts
+++ b/src/app/state/settings/models/settings-storage.ts
@@ -1,0 +1,11 @@
+const TOGGLE_EXPERIMENTAL = 'ExperimentalFeatures';
+
+export class SettingsStorage {
+  static toggleExperimental(value: string) {
+    localStorage.setItem(TOGGLE_EXPERIMENTAL, value);
+  }
+
+  static isExperimentalEnabled() {
+    return localStorage.getItem(TOGGLE_EXPERIMENTAL) === 'true';
+  }
+}

--- a/src/app/state/settings/settings-store-slice.module.ts
+++ b/src/app/state/settings/settings-store-slice.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { SettingsEffects } from './settings.effects';
+import { reducer, USER_FEATURE_KEY } from './settings.reducer';
+
+@NgModule({
+  imports: [
+    StoreModule.forFeature(USER_FEATURE_KEY, reducer),
+    EffectsModule.forFeature([SettingsEffects])
+  ],
+})
+export class SettingsStoreSliceModule {
+}

--- a/src/app/state/settings/settings.actions.ts
+++ b/src/app/state/settings/settings.actions.ts
@@ -1,0 +1,12 @@
+import { createAction } from '@ngrx/store';
+
+export const enableExperimental = createAction(
+  '[SETTINGS] Enable Experimental Features',
+);
+
+export const disableExperimental = createAction(
+  '[SETTINGS] Disable Experimental Features'
+);
+
+
+

--- a/src/app/state/settings/settings.effects.spec.ts
+++ b/src/app/state/settings/settings.effects.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ReplaySubject } from 'rxjs';
+
+import { SettingsEffects } from './settings.effects';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { SettingsState } from './settings.reducer';
+
+describe('SettingsEffects', () => {
+
+  let actions$: ReplaySubject<any>;
+  let effects: SettingsEffects;
+  let store: MockStore<SettingsState>;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SettingsEffects,
+        provideMockStore(),
+        provideMockActions(() => actions$),
+      ],
+    });
+    store = TestBed.inject(MockStore);
+
+    effects = TestBed.inject(SettingsEffects);
+  });
+
+
+});

--- a/src/app/state/settings/settings.effects.ts
+++ b/src/app/state/settings/settings.effects.ts
@@ -1,14 +1,30 @@
 import { Injectable } from '@angular/core';
-import { Actions } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import * as  SettingsActions from './settings.actions';
+import * as SettingsActions from './settings.actions';
 import { SettingsStorage } from './models/settings-storage';
+import { UrlService } from '../../shared/services/url-service/url.service';
+import { filter, map, switchMap } from 'rxjs/operators';
 
 @Injectable()
 export class SettingsEffects {
 
+  redirectFromAssetsToDashboard = createEffect(() =>
+    this.actions$
+      .pipe(
+        ofType(SettingsActions.disableExperimental),
+        switchMap(() => this.urlService.current
+          .pipe(
+            filter((url) => url.includes('assets')),
+            map(() => this.urlService.goTo('dashboard'))
+          )
+        )
+      ), {dispatch: false}
+  );
+
   constructor(private actions$: Actions,
-              private store: Store) {
+              private store: Store,
+              private urlService: UrlService) {
     this.enableExperimental();
   }
 

--- a/src/app/state/settings/settings.effects.ts
+++ b/src/app/state/settings/settings.effects.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import * as SettingsActions from './settings.actions';
 import { SettingsStorage } from './models/settings-storage';
 import { UrlService } from '../../shared/services/url-service/url.service';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, switchMap, take, tap } from 'rxjs/operators';
 
 @Injectable()
 export class SettingsEffects {
@@ -15,8 +15,9 @@ export class SettingsEffects {
         ofType(SettingsActions.disableExperimental),
         switchMap(() => this.urlService.current
           .pipe(
+            take(1),
             filter((url) => url.includes('assets')),
-            map(() => this.urlService.goTo('dashboard'))
+            tap(() => this.urlService.goTo('dashboard'))
           )
         )
       ), {dispatch: false}

--- a/src/app/state/settings/settings.effects.ts
+++ b/src/app/state/settings/settings.effects.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Actions } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import * as  SettingsActions from './settings.actions';
+import { SettingsStorage } from './models/settings-storage';
+
+@Injectable()
+export class SettingsEffects {
+
+  constructor(private actions$: Actions,
+              private store: Store) {
+    this.enableExperimental();
+  }
+
+  private enableExperimental() {
+    if (SettingsStorage.isExperimentalEnabled()) {
+      this.store.dispatch(SettingsActions.enableExperimental());
+    }
+  }
+}

--- a/src/app/state/settings/settings.reducer.spec.ts
+++ b/src/app/state/settings/settings.reducer.spec.ts
@@ -1,0 +1,2 @@
+describe('Settings Reducer', () => {
+});

--- a/src/app/state/settings/settings.reducer.ts
+++ b/src/app/state/settings/settings.reducer.ts
@@ -1,0 +1,29 @@
+import { Action, createReducer, on } from '@ngrx/store';
+import * as SettingsActions from './settings.actions';
+import { SettingsStorage } from './models/settings-storage';
+
+export const USER_FEATURE_KEY = 'settings';
+
+export interface SettingsState {
+  experimentalEnabled: boolean;
+}
+
+export const initialState: SettingsState = {
+  experimentalEnabled: false
+};
+
+const settingsReducer = createReducer(
+  initialState,
+  on(SettingsActions.enableExperimental, (state) => {
+    SettingsStorage.toggleExperimental('true');
+    return {...state, experimentalEnabled: true};
+  }),
+  on(SettingsActions.disableExperimental, (state) => {
+    SettingsStorage.toggleExperimental('false');
+    return {...state, experimentalEnabled: false};
+  })
+);
+
+export function reducer(state: SettingsState | undefined, action: Action) {
+  return settingsReducer(state, action);
+}

--- a/src/app/state/settings/settings.selectors.spec.ts
+++ b/src/app/state/settings/settings.selectors.spec.ts
@@ -1,0 +1,3 @@
+describe('Settings Selectors', () => {
+
+});

--- a/src/app/state/settings/settings.selectors.ts
+++ b/src/app/state/settings/settings.selectors.ts
@@ -1,0 +1,9 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { SettingsState, USER_FEATURE_KEY } from './settings.reducer';
+
+export const getSettingsState = createFeatureSelector<SettingsState>(USER_FEATURE_KEY);
+
+export const isExperimentalEnabled = createSelector(
+  getSettingsState,
+  (state) => state.experimentalEnabled
+);

--- a/src/app/state/store-root.module.ts
+++ b/src/app/state/store-root.module.ts
@@ -13,6 +13,7 @@ import { OrganizationStoreSliceModule } from './governance/organization/organiza
 import { LayoutStoreSliceModule } from './layout/layout-store-slice.module';
 import { ApplicationStoreSliceModule } from './governance/application/application-store-slice.module';
 import { RoleStoreSliceModule } from './governance/role/role-store-slice.module';
+import { SettingsStoreSliceModule } from './settings/settings-store-slice.module';
 
 
 @NgModule({
@@ -25,6 +26,7 @@ import { RoleStoreSliceModule } from './governance/role/role-store-slice.module'
     LayoutStoreSliceModule,
     ApplicationStoreSliceModule,
     RoleStoreSliceModule,
+    SettingsStoreSliceModule
   ],
 })
 export class StoreRootModule {


### PR DESCRIPTION
Things that need to be done when experimental features are disabled:

- [x] Disable assets page
- [x] Hide off-chain option while enrolling
- [x] Hide Create VC button.
- [x] Hide Assets columns and records connected to assets in enrollment page.

There is also a fix for filtering elements in enrolment view. Previously you could search only by namespace or did. Now those two filters are connected.