### PR TITLE
add initial architecture diagram + md render test

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,25 @@
+# EWF SSI/IAM Stack architecture
+
+## EWF SSI/IAM Stack Context Diagram
+
+Below is a [C4 context](https://c4model.com/#ContextDiagram) diagram of the EWF SSI/IAM stack.
+An objective of EWF IAM stack is that it can be used interoperably with parties using other SSI Wallets and Agents.
+Both SSI systems can trust EWF's SSI Governance (Switchboard Org/Apps/Roles).
+
+![ewf-ssi-context](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/energywebfoundation/switchboard-dapp/add-architecture-diagram/diagrams/ewf-ssi.context.plantuml)
+
+## EWF SSI/IAM Stack Container Diagram
+
+Below is a [C4 container](https://c4model.com/#ContainerDiagram) diagram of the EWF SSI/IAM stack.
+This diagram expresses that the EWF IAM stack is composed of an SSI Agent layer and a UI layer.
+For an introduction in the layering concept for SSI, see the [DIF FAQ](https://identity.foundation/faq/#how-is-this-faq-structured).
+
+The SSI Agent layer is currently spread across:
+- [iam-cache-server](https://github.com/energywebfoundation/iam-cache-server)
+- [ssi-server](https://github.com/energywebfoundation/ssi)
+
+EWF currently offers [Switchboard](https://github.com/energywebfoundation/switchboard-dapp) as a Wallet UI layer.
+
+![ewf-iam-stack](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/energywebfoundation/switchboard-dapp/add-architecture-diagram/diagrams/ewf-ssi.container.plantuml)
+
+## EWF IAM Stack Component Diagram

--- a/diagrams/ewf-ssi.container.plantuml
+++ b/diagrams/ewf-ssi.container.plantuml
@@ -1,0 +1,13 @@
+@startuml ewf-ssi-container
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+Person(ewf_wallet_user, "EWF SSI Wallet User")
+
+AddRelTag("dashed", $lineStyle = DashedLine())
+
+System_Boundary(ewf_stack, "EWF SSI/IAM Stack") {
+  Container(ssi_agent, "EWF SSI Agent", "iam-cache-server & ssi-server", "Encapsulate SSI functions. See DIF FAQ for agent definition.")
+  Container(switchboard, "Switchboad", "angular dapp", "UI for Governance and SSI Wallet functions")
+}
+
+@enduml

--- a/diagrams/ewf-ssi.context.plantuml
+++ b/diagrams/ewf-ssi.context.plantuml
@@ -1,0 +1,21 @@
+@startuml ewf-ssi-container
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+
+Person(ewf_wallet_user, "EWF SSI Wallet User")
+Person(ewf_role_governance_user, "EWF Role Governance User")
+Person(other_stack_user, "Other SSI User")
+
+AddRelTag("dashed", $lineStyle = DashedLine())
+System(ewf_ssi_wallet, "EWF SSI Wallet", "")
+System(ewf_role_governance, "EWF SSI Governance", "")
+System(other_ssi_stack, "Other SSI Wallet")
+
+Rel(ewf_role_governance_user, ewf_role_governance, "Configures")
+Rel(ewf_wallet_user, ewf_ssi_wallet, "Operates")
+Rel(other_stack_user, other_ssi_stack, "Operates")
+Rel(ewf_ssi_wallet, other_ssi_stack, "Exchange Credentials")
+Rel(other_ssi_stack, ewf_ssi_wallet, "Exchange Credentials")
+Rel(ewf_ssi_wallet, ewf_role_governance, "Trusts")
+Rel(other_ssi_stack, ewf_role_governance, "Trusts")
+
+@enduml


### PR DESCRIPTION
I'm thinking of starting to add c4 diagrams of the EWF IAM stack to the Switchboard repo (as it can be seen as the main repo for the EWF IAM stack). What do you think of this?

You can see the documentation here: https://github.com/energywebfoundation/switchboard-dapp/blob/add-architecture-diagram/architecture.md