### PR TITLE
fix: renovate PRs with updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ karma-headless.conf.js
 eslint_report.json
 coverage/
 .angular/
+package-lock.json


### PR DESCRIPTION
Renovate is failing when updating package-lock.json file, because prettier is checking that file. I think it is not needed to check that file as this is managed by npm.