### PR TITLE
fix: displaying text near qr code icon

### DIFF
--- a/src/app/layout/components/user-menu/user-did/user-did.component.html
+++ b/src/app/layout/components/user-menu/user-did/user-did.component.html
@@ -11,5 +11,5 @@
   appQrCode
   [data]="qrCodeData">
   User Data QR Code
-  <mat-icon class="ml-2 color-white" svgIcon="generate-qr-icon">generate-qr-icon</mat-icon>
+  <mat-icon class="ml-2 color-white" svgIcon="generate-qr-icon"></mat-icon>
 </div>


### PR DESCRIPTION
@Harasz mentioned that he see text in user menu near qr code. This should fix this issue.