### PR TITLE
fix(sync claim): check for synced on chain to determine registration …

### DIFF
--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -247,17 +247,15 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         this.getList(this.dynamicRejected, this.dynamicAccepted);
       });
   }
-  //the method to checke element
   async addToDidDoc(element: EnrolmentClaim) {
-      console.log("in add to did doc method");
     const isRegisteredOnChain = await this.publishRoleService.checkForNotSyncedOnChain(element);
     const {notSyncedOnChain} = isRegisteredOnChain;
-    console.log(notSyncedOnChain, "NOT SYNCED ON CHAIN")
+    // If the element is already synced on chain, only off-chain registration is needed:
     const registrationTypes = notSyncedOnChain ? element.registrationTypes : [RegistrationTypes.OffChain];
     this.publishRoleService
       .addToDidDoc({
         issuedToken: element.issuedToken,
-        registrationTypes: registrationTypes,
+        registrationTypes,
         claimType: element.claimType,
       })
       .pipe(truthy())

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { NamespaceType } from 'iam-client-lib';
+import { NamespaceType, RegistrationTypes } from 'iam-client-lib';
 import { take, takeUntil } from 'rxjs/operators';
 import { combineLatest, of, Subject } from 'rxjs';
 import { IamService } from '../../../shared/services/iam.service';
@@ -247,12 +247,17 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         this.getList(this.dynamicRejected, this.dynamicAccepted);
       });
   }
-
-  addToDidDoc(element: EnrolmentClaim) {
+  //the method to checke element
+  async addToDidDoc(element: EnrolmentClaim) {
+      console.log("in add to did doc method");
+    const isRegisteredOnChain = await this.publishRoleService.checkForNotSyncedOnChain(element);
+    const {notSyncedOnChain} = isRegisteredOnChain;
+    console.log(notSyncedOnChain, "NOT SYNCED ON CHAIN")
+    const registrationTypes = notSyncedOnChain ? element.registrationTypes : [RegistrationTypes.OffChain];
     this.publishRoleService
       .addToDidDoc({
         issuedToken: element.issuedToken,
-        registrationTypes: element.registrationTypes,
+        registrationTypes: registrationTypes,
         claimType: element.claimType,
       })
       .pipe(truthy())

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -253,7 +253,7 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
         issuedToken: element.issuedToken,
         registrationTypes: element.registrationTypes,
         claimType: element.claimType,
-        claimTypeVersion: element.claimTypeVersion
+        claimTypeVersion: element.claimTypeVersion,
       })
       .pipe(truthy())
       .subscribe(async () => await this.getList(this.rejected, this.accepted));

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -248,10 +248,13 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
       });
   }
   async addToDidDoc(element: EnrolmentClaim) {
-    const isRegisteredOnChain = await this.publishRoleService.checkForNotSyncedOnChain(element);
-    const {notSyncedOnChain} = isRegisteredOnChain;
+    const isRegisteredOnChain =
+      await this.publishRoleService.checkForNotSyncedOnChain(element);
+    const { notSyncedOnChain } = isRegisteredOnChain;
     // If the element is already synced on chain, only off-chain registration is needed:
-    const registrationTypes = notSyncedOnChain ? element.registrationTypes : [RegistrationTypes.OffChain];
+    const registrationTypes = notSyncedOnChain
+      ? element.registrationTypes
+      : [RegistrationTypes.OffChain];
     this.publishRoleService
       .addToDidDoc({
         issuedToken: element.issuedToken,

--- a/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
+++ b/src/app/routes/enrolment/enrolment-list/enrolment-list.component.ts
@@ -248,18 +248,12 @@ export class EnrolmentListComponent implements OnInit, OnDestroy {
       });
   }
   async addToDidDoc(element: EnrolmentClaim) {
-    const isRegisteredOnChain =
-      await this.publishRoleService.checkForNotSyncedOnChain(element);
-    const { notSyncedOnChain } = isRegisteredOnChain;
-    // If the element is already synced on chain, only off-chain registration is needed:
-    const registrationTypes = notSyncedOnChain
-      ? element.registrationTypes
-      : [RegistrationTypes.OffChain];
     this.publishRoleService
       .addToDidDoc({
         issuedToken: element.issuedToken,
-        registrationTypes,
+        registrationTypes: element.registrationTypes,
         claimType: element.claimType,
+        claimTypeVersion: element.claimTypeVersion
       })
       .pipe(truthy())
       .subscribe(async () => await this.getList(this.rejected, this.accepted));

--- a/src/app/shared/services/publish-role/publish-role.service.spec.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.spec.ts
@@ -59,7 +59,7 @@ describe('PublishRoleService', () => {
           issuedToken: 'some-token',
           registrationTypes: [],
           claimType: '',
-          claimTypeVersion: "1",
+          claimTypeVersion: '1',
         })
         .subscribe((v) => {
           expect(toastrSpy.success).toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe('PublishRoleService', () => {
           issuedToken: 'some-token',
           registrationTypes: [],
           claimType: '',
-          claimTypeVersion: "1",
+          claimTypeVersion: '1',
         })
         .subscribe((v) => {
           expect(toastrSpy.warning).toHaveBeenCalled();

--- a/src/app/shared/services/publish-role/publish-role.service.spec.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.spec.ts
@@ -59,6 +59,7 @@ describe('PublishRoleService', () => {
           issuedToken: 'some-token',
           registrationTypes: [],
           claimType: '',
+          claimTypeVersion: "1",
         })
         .subscribe((v) => {
           expect(toastrSpy.success).toHaveBeenCalled();
@@ -75,6 +76,7 @@ describe('PublishRoleService', () => {
           issuedToken: 'some-token',
           registrationTypes: [],
           claimType: '',
+          claimTypeVersion: "1",
         })
         .subscribe((v) => {
           expect(toastrSpy.warning).toHaveBeenCalled();

--- a/src/app/shared/services/publish-role/publish-role.service.spec.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.spec.ts
@@ -54,6 +54,7 @@ describe('PublishRoleService', () => {
 
     it('should return true', (done) => {
       claimsFacadeSpy.publishPublicClaim.and.returnValue(of(true));
+      claimsFacadeSpy.hasOnChainRole.and.returnValue(Promise.resolve(false));
       service
         .addToDidDoc({
           issuedToken: 'some-token',
@@ -71,6 +72,7 @@ describe('PublishRoleService', () => {
 
     it('should return false', (done) => {
       claimsFacadeSpy.publishPublicClaim.and.returnValue(of(undefined));
+      claimsFacadeSpy.hasOnChainRole.and.returnValue(Promise.resolve(false));
       service
         .addToDidDoc({
           issuedToken: 'some-token',
@@ -83,6 +85,55 @@ describe('PublishRoleService', () => {
           expect(v).toBeFalse();
           done();
         });
+    });
+    it('should publish only with OffChain when onChain is synced', (done) => {
+      claimsFacadeSpy.publishPublicClaim.and.returnValue(of(true));
+      claimsFacadeSpy.hasOnChainRole.and.returnValue(Promise.resolve(true));
+      const enrolment = {
+        issuedToken: 'some-token',
+        registrationTypes: [
+          RegistrationTypes.OnChain,
+          RegistrationTypes.OffChain,
+        ],
+        claimType: '',
+        claimTypeVersion: '1',
+      };
+      service.addToDidDoc(enrolment).subscribe(() => {
+        expect(claimsFacadeSpy.publishPublicClaim).toHaveBeenCalledOnceWith({
+          registrationTypes: [RegistrationTypes.OffChain],
+          claim: {
+            token: enrolment.issuedToken,
+            claimType: enrolment.claimType,
+          },
+        });
+        done();
+      });
+    });
+    it('should publish with OnChain and OffChain when onChain is not synced', (done) => {
+      claimsFacadeSpy.publishPublicClaim.and.returnValue(of(true));
+      claimsFacadeSpy.hasOnChainRole.and.returnValue(Promise.resolve(false));
+      const enrolment = {
+        issuedToken: 'some-token',
+        registrationTypes: [
+          RegistrationTypes.OnChain,
+          RegistrationTypes.OffChain,
+        ],
+        claimType: '',
+        claimTypeVersion: '1',
+      };
+      service.addToDidDoc(enrolment).subscribe(() => {
+        expect(claimsFacadeSpy.publishPublicClaim).toHaveBeenCalledOnceWith({
+          registrationTypes: [
+            RegistrationTypes.OnChain,
+            RegistrationTypes.OffChain,
+          ],
+          claim: {
+            token: enrolment.issuedToken,
+            claimType: enrolment.claimType,
+          },
+        });
+        done();
+      });
     });
   });
 

--- a/src/app/shared/services/publish-role/publish-role.service.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.ts
@@ -10,7 +10,7 @@ import { CancelButton } from '../../../layout/loading/loading.component';
 import { LoadingService } from '../loading.service';
 import { SwitchboardToastrService } from '../switchboard-toastr.service';
 import { NotificationService } from '../notification.service';
-import { catchError, finalize, map, switchMap, mergeMap } from 'rxjs/operators';
+import { catchError, finalize, map, switchMap } from 'rxjs/operators';
 import { from, of } from 'rxjs';
 import { ClaimsFacadeService } from '../claims-facade/claims-facade.service';
 import {

--- a/src/app/shared/services/publish-role/publish-role.service.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.ts
@@ -120,6 +120,7 @@ export class PublishRoleService {
     issuedToken: string;
     registrationTypes: RegistrationTypes[];
     claimType: string;
+    claimTypeVersion: string;
   }) {
     const isRegisteredOnChain = await this.checkForNotSyncedOnChain(element);
     const { notSyncedOnChain } = isRegisteredOnChain;
@@ -141,6 +142,7 @@ export class PublishRoleService {
       })
       .pipe(
         map((retVal) => {
+            console.log(retVal, "THE RET VAL@@@@")
           if (retVal) {
             this.notifService.decreasePendingDidDocSyncCount();
             this.toastr.success('Action is successful.', 'Publish');


### PR DESCRIPTION
https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54/backlog?selectedIssue=SWTCH-1338
- When publishing (syncing claim to DID doc), first check that it is not already registered on chain. 
- This avoids a re-registering on chain if a user has accepted the transaction to sync a claim on chain, rejected the transaction to sync off-chain, then re-attempts the publish process again. 

https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54/backlog?selectedIssue=SWTCH-1338 