### PR TITLE
fix(exp): do not send NaN as expiration date to ICL request

### DIFF
--- a/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.spec.ts
+++ b/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.spec.ts
@@ -40,6 +40,7 @@ describe('ExpirationDateComponent', () => {
     component = fixture.componentInstance;
     hostDebug = fixture.debugElement;
     spyOn(component.add, 'emit');
+    spyOn(component.remove, 'emit');
     jasmine.clock().install();
     baseTime = new Date(2000, 0, 1, 1, 0, 0);
     timezoneSeconds = baseTime.getTimezoneOffset() * 60;
@@ -90,7 +91,7 @@ describe('ExpirationDateComponent', () => {
     removeButton.click();
     fixture.detectChanges();
 
-    expect(component.remove.emit).toHaveBeenCalled;
+    expect(component.remove.emit).toHaveBeenCalled();
     expect(component.expirationDate.value).toEqual('');
   });
 

--- a/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.spec.ts
+++ b/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.spec.ts
@@ -82,7 +82,7 @@ describe('ExpirationDateComponent', () => {
     );
   });
 
-  it('should check if remove button sets expiration time as undefined', () => {
+  it('should check if remove button calls "remove" to set the expiration time as null', () => {
     component.defaultValidityPeriod = 100;
     fixture.detectChanges();
 
@@ -90,7 +90,8 @@ describe('ExpirationDateComponent', () => {
     removeButton.click();
     fixture.detectChanges();
 
-    expect(component.add.emit).toHaveBeenCalledWith(undefined);
+    expect(component.remove.emit).toHaveBeenCalled;
+    expect(component.expirationDate.value).toEqual('');
   });
 
   it('should set default time in input from current time', () => {

--- a/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.ts
+++ b/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.ts
@@ -18,7 +18,7 @@ import { takeUntil } from 'rxjs/operators';
 export class ExpirationDateComponent implements OnInit, OnDestroy {
   @Input() defaultValidityPeriod: number;
   @Output() add: EventEmitter<number> = new EventEmitter<number>();
-  @Output() remove: EventEmitter<number> = new EventEmitter<number>();
+  @Output() remove: EventEmitter<void> = new EventEmitter<void>();
 
   expirationDate = new FormControl('');
   expirationTimeShift: number;

--- a/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.ts
+++ b/src/app/routes/enrolment/view-requests/components/expiration-date/expiration-date.component.ts
@@ -18,6 +18,7 @@ import { takeUntil } from 'rxjs/operators';
 export class ExpirationDateComponent implements OnInit, OnDestroy {
   @Input() defaultValidityPeriod: number;
   @Output() add: EventEmitter<number> = new EventEmitter<number>();
+  @Output() remove: EventEmitter<number> = new EventEmitter<number>();
 
   expirationDate = new FormControl('');
   expirationTimeShift: number;
@@ -45,7 +46,7 @@ export class ExpirationDateComponent implements OnInit, OnDestroy {
 
   removeHandler(): void {
     this.expirationDate.setValue('');
-    this.add.emit(undefined);
+    this.remove.emit();
     this.hideRemoveButton = true;
   }
 

--- a/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.html
+++ b/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.html
@@ -35,7 +35,9 @@
         <app-expiration-date
           data-qa-id="expiration-date"
           [defaultValidityPeriod]="roleDefinition?.defaultValidityPeriod"
-          (add)="updateExpirationDate($event)"></app-expiration-date>
+          (add)="setExpirationTimeUsingValidity($event)"
+          (remove)="clearExpirationDate()">
+        </app-expiration-date>
       </div>
 
       <div class="col-lg-12 mt-2" *ngIf="claim?.registrationTypes?.length === 2 && !claim.isAccepted">

--- a/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
+++ b/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
@@ -83,8 +83,12 @@ export class IssuerRequestsComponent
     this.dialogRef.close(true);
   }
 
-  updateExpirationDate(validityPeriod: number | undefined): void {
-    this.expirationTime = validityPeriod ? Date.now() + validityPeriod : null;
+  setExpirationTimeUsingValidity(validityPeriod: number): void {
+    this.expirationTime = Date.now() + validityPeriod;
+  }
+
+  clearExpirationDate(): void {
+    this.expirationTime = null;
   }
 
   private getRoleIssuerFields(namespace: string): void {

--- a/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
+++ b/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
@@ -83,8 +83,8 @@ export class IssuerRequestsComponent
     this.dialogRef.close(true);
   }
 
-  updateExpirationDate(validityPeriod: number): void {
-    this.expirationTime = Date.now() + validityPeriod;
+  updateExpirationDate(validityPeriod: number | undefined): void {
+    this.expirationTime = validityPeriod ? Date.now() + validityPeriod : null;
   }
 
   private getRoleIssuerFields(namespace: string): void {


### PR DESCRIPTION
- Was sending NaN to ICL as expirationTimestamp if date was removed. While this didn't affect ICL behavior as it is falsey, I think it should be changed to null in this case. 