### PR TITLE
fix: Do not show Cancel Claim Request if claim is Revoked

### DIFF
--- a/src/app/routes/enrolment/models/enrolment-claim.spec.ts
+++ b/src/app/routes/enrolment/models/enrolment-claim.spec.ts
@@ -229,6 +229,60 @@ describe('EnrolmentClaim tests', () => {
       ).toBeTrue();
     });
   });
+  describe('canCancelClaimRequest', () => {
+    it('should return true when the claim is accepted, not rejected and not revoked on-chain and not-revoked off-chain', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: false,
+          isRejected: false,
+        } as Claim)
+          .setIsRevokedOffChain(false)
+          .setIsRevokedOnChain(false).canCancelClaimRequest
+      ).toBeTrue();
+    });
+    it('should return false when the claim is accepted', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          isRejected: false,
+        } as Claim)
+          .setIsRevokedOffChain(false)
+          .setIsRevokedOnChain(false).canCancelClaimRequest
+      ).toBeFalse();
+    });
+    it('should return false when the claim is rejected', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: false,
+          isRejected: true,
+        } as Claim)
+          .setIsRevokedOffChain(false)
+          .setIsRevokedOnChain(false).canCancelClaimRequest
+      ).toBeFalse();
+    });
+
+    it('should return false when the claim is revoked off-chain', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          isRejected: false,
+        } as Claim)
+          .setIsRevokedOffChain(true)
+          .setIsRevokedOnChain(false).canCancelClaimRequest
+      ).toBeFalse();
+    });
+
+    it('should return false when the claim is revoked off-chain', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          isRejected: false,
+        } as Claim)
+          .setIsRevokedOffChain(false)
+          .setIsRevokedOnChain(true).canCancelClaimRequest
+      ).toBeFalse();
+    });
+  });
 
   describe('isRevoked', () => {
     it('should return true if is revoked only off chain', () => {

--- a/src/app/routes/enrolment/models/enrolment-claim.ts
+++ b/src/app/routes/enrolment/models/enrolment-claim.ts
@@ -107,6 +107,15 @@ export class EnrolmentClaim
     );
   }
 
+  get canCancelClaimRequest(): boolean {
+    return (
+      !this.iclClaim.isAccepted &&
+      !this.iclClaim.isRejected &&
+      !this.isRevokedOffChain &&
+      !this.isRevokedOnChain
+    );
+  }
+
   setIsRevokedOnChain(isRevoked: boolean): EnrolmentClaim {
     this.isRevokedOnChain = isRevoked;
     return this;

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
@@ -16,7 +16,7 @@
     mat-menu-item
     class="btn-color-error"
     (click)="cancelClaimRequest(element)"
-    *ngIf="!element?.isAccepted && !element?.isRejected && !element.isRevokedOffChain && !element.isRevokedOnChain">
+    *ngIf="showCancelClaimOption(element)">
     <mat-icon class="btn-color-error">highlight_off</mat-icon>
     <span>Cancel Claim Request</span>
   </button>

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
@@ -15,8 +15,8 @@
   <button
     mat-menu-item
     class="btn-color-error"
-    (click)="element.canCancelClaimRequest"
-    *ngIf="showCancelClaimOption(element)">
+    (click)="cancelClaimRequest(element)"
+    *ngIf="element.canCancelClaimRequest">
     <mat-icon class="btn-color-error">highlight_off</mat-icon>
     <span>Cancel Claim Request</span>
   </button>

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
@@ -16,7 +16,7 @@
     mat-menu-item
     class="btn-color-error"
     (click)="cancelClaimRequest(element)"
-    *ngIf="!element?.isAccepted && !element?.isRejected">
+    *ngIf="!element?.isAccepted && !element?.isRejected && !element.isRevokedOffChain && !element.isRevokedOnChain">
     <mat-icon class="btn-color-error">highlight_off</mat-icon>
     <span>Cancel Claim Request</span>
   </button>

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
@@ -15,7 +15,7 @@
   <button
     mat-menu-item
     class="btn-color-error"
-    (click)="cancelClaimRequest(element)"
+    (click)="element.canCancelClaimRequest"
     *ngIf="showCancelClaimOption(element)">
     <mat-icon class="btn-color-error">highlight_off</mat-icon>
     <span>Cancel Claim Request</span>

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
@@ -93,6 +93,15 @@ export class MyEnrolmentListComponent implements OnInit, OnDestroy {
     return !element?.isSynced;
   }
 
+  showCancelClaimOption(element: EnrolmentClaim) {
+    return (
+      !element?.isAccepted &&
+      !element?.isRejected &&
+      !element.isRevokedOffChain &&
+      !element.isRevokedOnChain
+    );
+  }
+
   view(element: EnrolmentClaim) {
     this.dialog
       .open(ViewRequestsComponent, {

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
@@ -93,15 +93,6 @@ export class MyEnrolmentListComponent implements OnInit, OnDestroy {
     return !element?.isSynced;
   }
 
-  showCancelClaimOption(element: EnrolmentClaim) {
-    return (
-      !element?.isAccepted &&
-      !element?.isRejected &&
-      !element.isRevokedOffChain &&
-      !element.isRevokedOnChain
-    );
-  }
-
   view(element: EnrolmentClaim) {
     this.dialog
       .open(ViewRequestsComponent, {


### PR DESCRIPTION
- Do not show Cancel Claim Request button in "My Enrolments" view IF the enrolment is revoked on-chain, or if it is revoked off-chain. 

<img width="1345" alt="Screen Shot 2022-08-01 at 11 35 46 AM" src="https://user-images.githubusercontent.com/83423498/182187858-0394f014-0395-4df5-b20b-4a140b597bcf.png">
<img width="1382" alt="Screen Shot 2022-08-01 at 11 35 31 AM" src="https://user-images.githubusercontent.com/83423498/182187918-91c1164b-5331-424a-bc04-efe01ec36a30.png">

For some reason, I can;t override the min-height on the mat-menu-panel, even if I put !important. I wish I could because it looks a little too tall when there is just one button...