### PR TITLE
fix: errors when reinitializing SB with wrong metamask network id

### DIFF
--- a/src/app/core/config/chain-id.ts
+++ b/src/app/core/config/chain-id.ts
@@ -1,0 +1,8 @@
+import { VOLTA_CHAIN_ID } from 'iam-client-lib';
+
+export const ChainId = {
+  Volta: VOLTA_CHAIN_ID,
+  VoltaHex: '0x12047',
+  EWC: 246,
+  EwcHex: '0xF6',
+};

--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -30,6 +30,7 @@ export class LayoutComponent implements OnInit {
       icon: 'error',
       button: 'Proceed',
       closeOnClickOutside: false,
+      closeOnEsc: false,
     };
 
     const result = await swal(config);

--- a/src/app/shared/services/login/helpers/login-swal.buttons.ts
+++ b/src/app/shared/services/login/helpers/login-swal.buttons.ts
@@ -1,0 +1,4 @@
+export enum LoginSwalButtons {
+  Proceed = 'proceed',
+  Import = 'import',
+}

--- a/src/app/shared/services/login/login.service.spec.ts
+++ b/src/app/shared/services/login/login.service.spec.ts
@@ -10,14 +10,19 @@ import { from, of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { iamServiceSpy, loadingServiceSpy, toastrSpy } from '@tests';
 import { IS_ETH_SIGNER, ProviderType, PUBLIC_KEY } from 'iam-client-lib';
+import { MetamaskProviderService } from '../metamask-provider/metamask-provider.service';
 
 describe('LoginService', () => {
   let service: LoginService;
+  let metamaskServiceSpy;
   const iamListenerServiceSpy = jasmine.createSpyObj('IamListenerService', [
     'setListeners',
   ]);
 
   beforeEach(() => {
+    metamaskServiceSpy = jasmine.createSpyObj('MetamaskProviderService', [
+      'importMetamaskConf',
+    ]);
     TestBed.configureTestingModule({
       providers: [
         provideMockStore(),
@@ -25,6 +30,7 @@ describe('LoginService', () => {
         { provide: LoadingService, useValue: loadingServiceSpy },
         { provide: IamService, useValue: iamServiceSpy },
         { provide: IamListenerService, useValue: iamListenerServiceSpy },
+        { provide: MetamaskProviderService, useValue: metamaskServiceSpy },
       ],
     });
     service = TestBed.inject(LoginService);

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -206,7 +206,7 @@ export class LoginService {
   public wrongNetwork() {
     if (this.isSessionActive()) {
       this.openSwal(
-        { title: 'Ops!', text: "You're using wrong network" },
+        { title: 'Oops!', text: "You're using the wrong network" },
         false
       );
     }
@@ -218,6 +218,7 @@ export class LoginService {
         icon: 'error',
         button: 'Proceed',
         closeOnClickOutside: false,
+        closeOnEsc: false,
         ...config,
       })
     )
@@ -235,7 +236,7 @@ export class LoginService {
       this.loadingService.hide();
       this.openSwal(
         {
-          title: 'Ops!',
+          title: 'Oops!',
           text: 'Something went wrong :(',
         },
         true

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -11,8 +11,19 @@ import {
 import SWAL from 'sweetalert';
 import { from, Observable, of } from 'rxjs';
 import { IamListenerService } from '../iam-listener/iam-listener.service';
-import { catchError, delayWhen, filter, map, take } from 'rxjs/operators';
+import {
+  catchError,
+  delayWhen,
+  filter,
+  map,
+  share,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs/operators';
 import { swalLoginError } from './helpers/swal-login-error-handler';
+import { LoginSwalButtons } from './helpers/login-swal.buttons';
+import { MetamaskProviderService } from '../metamask-provider/metamask-provider.service';
 
 export interface LoginOptions {
   providerType?: ProviderType;
@@ -48,7 +59,8 @@ export class LoginService {
     private loadingService: LoadingService,
     private iamService: IamService,
     private toastr: ToastrService,
-    private iamListenerService: IamListenerService
+    private iamListenerService: IamListenerService,
+    private metamaskService: MetamaskProviderService
   ) {}
 
   isSessionActive() {
@@ -143,8 +155,7 @@ export class LoginService {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setDeepLink(deepLink: any) {
+  setDeepLink(deepLink: string) {
     this._deepLink = deepLink;
   }
 
@@ -205,10 +216,28 @@ export class LoginService {
 
   public wrongNetwork() {
     if (this.isSessionActive()) {
-      this.openSwal(
-        { title: 'Oops!', text: "You're using the wrong network" },
-        false
-      );
+      const swalSubscription = from(
+        SWAL({
+          icon: 'error',
+          closeOnClickOutside: false,
+          closeOnEsc: false,
+          title: 'Oops!',
+          text: "You're using the wrong network",
+          buttons: {
+            [LoginSwalButtons.Proceed]: {
+              text: 'Proceed',
+              closeModal: false,
+            },
+            [LoginSwalButtons.Import]: {
+              text: 'Import configuration',
+              closeModal: false,
+            },
+          },
+        })
+      ).pipe(take(1), share());
+
+      this.proceedLogout(swalSubscription);
+      this.importMMConfig(swalSubscription);
     }
   }
 
@@ -216,7 +245,12 @@ export class LoginService {
     from(
       SWAL({
         icon: 'error',
-        button: 'Proceed',
+        buttons: {
+          [LoginSwalButtons.Proceed]: {
+            text: 'Proceed',
+            closeModal: false,
+          },
+        },
         closeOnClickOutside: false,
         closeOnEsc: false,
         ...config,
@@ -279,5 +313,33 @@ export class LoginService {
     };
 
     this.openSwal(config, navigateOnTimeout);
+  }
+
+  private proceedLogout(buttonSubscription: Observable<LoginSwalButtons>) {
+    buttonSubscription
+      .pipe(
+        filter(
+          (buttonName: LoginSwalButtons) =>
+            buttonName === LoginSwalButtons.Proceed
+        )
+      )
+      .subscribe(() => this.disconnect());
+  }
+
+  private importMMConfig(buttonSubscription: Observable<LoginSwalButtons>) {
+    buttonSubscription
+      .pipe(
+        filter(
+          (buttonName: LoginSwalButtons) =>
+            buttonName === LoginSwalButtons.Import
+        )
+      )
+      .subscribe(async () => {
+        this.loadingService.show(
+          'Switching network... Please check Your Metamask '
+        );
+        await this.metamaskService.importMetamaskConf();
+        this.loadingService.hide();
+      });
   }
 }

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -85,6 +85,10 @@ export class LoginService {
     return this.iamService.providerType;
   }
 
+  isMetamaskProvider(): boolean {
+    return localStorage.getItem(PROVIDER_TYPE) === ProviderType.MetaMask;
+  }
+
   /**
    * Login via IAM and retrieve basic user info
    */
@@ -196,6 +200,15 @@ export class LoginService {
     if (this._throwTimeoutError) {
       this._throwTimeoutError = false;
       throw new Error('Wallet Signature Timeout');
+    }
+  }
+
+  public wrongNetwork() {
+    if (this.isSessionActive()) {
+      this.openSwal(
+        { title: 'Ops!', text: "You're using wrong network" },
+        false
+      );
     }
   }
 

--- a/src/app/shared/styles/app/for-theme.scss
+++ b/src/app/shared/styles/app/for-theme.scss
@@ -976,7 +976,9 @@ mat-label {
 }
 
 .swal-button.swal-button--viewMyEnrolments,
-.swal-button--enrolForAsset {
+.swal-button--enrolForAsset,
+.swal-button--proceed,
+.swal-button--import {
   color: var(--default-text-color) !important;
   background-color: var(--button-primary);
   border: 1px solid var(--button-primary);

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -16,6 +16,7 @@ import { ConnectToWalletDialogComponent } from '../../modules/connect-to-wallet/
 import * as AuthSelectors from './auth.selectors';
 import { EnvService } from '../../shared/services/env/env.service';
 import { RouterConst } from '../../routes/router-const';
+import { ChainId } from '../../core/config/chain-id';
 
 describe('AuthEffects', () => {
   let loginServiceSpy;
@@ -41,7 +42,9 @@ describe('AuthEffects', () => {
       'isMetamaskProvider',
       'wrongNetwork',
     ]);
-    envServiceSpy = jasmine.createSpyObj('EnvService', [], { chainId: 73799 });
+    envServiceSpy = jasmine.createSpyObj('EnvService', [], {
+      chainId: ChainId.Volta,
+    });
     TestBed.configureTestingModule({
       providers: [
         AuthEffects,
@@ -114,7 +117,10 @@ describe('AuthEffects', () => {
     it('should not call wrongNetwork when metamask is present and chainId is correct', () => {
       loginServiceSpy.isMetamaskProvider.and.returnValue(true);
       actions$.next(
-        AuthActions.setMetamaskLoginOptions({ present: true, chainId: 73799 })
+        AuthActions.setMetamaskLoginOptions({
+          present: true,
+          chainId: ChainId.Volta,
+        })
       );
 
       effects.checkNetwork$.subscribe();

--- a/src/app/state/auth/auth.selectors.spec.ts
+++ b/src/app/state/auth/auth.selectors.spec.ts
@@ -24,7 +24,7 @@ describe('Auth Selectors', () => {
     it('should return false when metamaskChainId is set to Volta chain', () => {
       expect(
         authSelectors.isMetamaskDisabled.projector({
-          metamask: { chainId: '0x12047' },
+          metamask: { chainId: 73799 },
           defaultChainId: 73799,
         })
       ).toBeFalsy();

--- a/src/app/state/auth/auth.selectors.spec.ts
+++ b/src/app/state/auth/auth.selectors.spec.ts
@@ -1,5 +1,6 @@
 import * as authSelectors from './auth.selectors';
 import { ProviderType } from 'iam-client-lib';
+import { ChainId } from '../../core/config/chain-id';
 
 describe('Auth Selectors', () => {
   describe('isMetamaskDisabled', () => {
@@ -24,8 +25,8 @@ describe('Auth Selectors', () => {
     it('should return false when metamaskChainId is set to Volta chain', () => {
       expect(
         authSelectors.isMetamaskDisabled.projector({
-          metamask: { chainId: 73799 },
-          defaultChainId: 73799,
+          metamask: { chainId: ChainId.Volta },
+          defaultChainId: ChainId.Volta,
         })
       ).toBeFalsy();
     });

--- a/src/app/state/auth/auth.selectors.ts
+++ b/src/app/state/auth/auth.selectors.ts
@@ -15,9 +15,7 @@ export const isMetamaskPresent = createSelector(
 
 export const isMetamaskDisabled = createSelector(
   getAuthState,
-  (state) =>
-    state?.metamask.chainId &&
-    parseInt(`${state?.metamask.chainId}`, 16) !== state?.defaultChainId
+  (state) => state?.metamask.chainId !== state?.defaultChainId
 );
 
 export const getWalletProvider = createSelector(

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,4 +1,5 @@
 import { constants } from './constants';
+import { ChainId } from '../app/core/config/chain-id';
 
 export const environment = {
   production: true,
@@ -6,7 +7,7 @@ export const environment = {
   application: true,
 
   rpcUrl: 'https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/',
-  chainId: 73799,
+  chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
   kmsServerUrl: undefined,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 import { constants } from './constants';
+import { ChainId } from '../app/core/config/chain-id';
 
 export const environment = {
   production: true,
@@ -6,7 +7,7 @@ export const environment = {
   application: true,
 
   rpcUrl: 'https://rpc.energyweb.org/',
-  chainId: 246,
+  chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache.energyweb.org/v1',
   natsServerUrl: 'https://identityevents.energyweb.org/',
   kmsServerUrl: 'https://kms.energyweb.org/connect/new',

--- a/src/environments/environment.stedin.ts
+++ b/src/environments/environment.stedin.ts
@@ -1,4 +1,5 @@
 import { constants } from './constants';
+import { ChainId } from '../app/core/config/chain-id';
 
 export const environment = {
   production: false,
@@ -6,7 +7,7 @@ export const environment = {
   application: false,
 
   rpcUrl: 'https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/',
-  chainId: 73799,
+  chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
   kmsServerUrl: undefined,

--- a/src/environments/environment.stg.ts
+++ b/src/environments/environment.stg.ts
@@ -1,4 +1,5 @@
 import { constants } from './constants';
+import { ChainId } from '../app/core/config/chain-id';
 
 export const environment = {
   production: true,
@@ -6,7 +7,7 @@ export const environment = {
   application: true,
 
   rpcUrl: 'https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/',
-  chainId: 73799,
+  chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-staging.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-staging.energyweb.org/',
   kmsServerUrl: 'https://kms.energyweb.org/connect/new',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 import { constants } from './constants';
+import { ChainId } from '../app/core/config/chain-id';
 
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
@@ -10,7 +11,7 @@ export const environment = {
   application: true,
 
   rpcUrl: 'https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/',
-  chainId: 73799,
+  chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/SWTCH-1379
Fix works like this:
1. When app detects metamask with wrong chainId but will try to reinitialize with wrong chainId, then popup with logout button will be displayed.
2. When metamask is not present, then it's doing nothing.
3. when chain id is wrong, but it will not try to reinitialize with metamask (for example user was using mobile connect), then nothing is doing.