### PR TITLE
fix(exp): do not show 'Publish' button for expired claims

### DIFF
--- a/src/app/routes/enrolment/enrolment-list/filter-builder/filter.builder.ts
+++ b/src/app/routes/enrolment/enrolment-list/filter-builder/filter.builder.ts
@@ -106,9 +106,7 @@ export class FilterBuilder {
       );
     }
     if (status === FilterStatus.Expired) {
-      return list.filter(
-        (item) => item.expirationStatus === ExpirationStatus.EXPIRED
-      );
+      return list.filter((item) => item.isExpired);
     }
   }
 

--- a/src/app/routes/enrolment/enrolment-status/enrolment-status.component.html
+++ b/src/app/routes/enrolment/enrolment-status/enrolment-status.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="claim?.isAccepted">
   <div class="d-flex flex-column align-items-md-center flex-md-row justify-content-between mr-2">
     <div class="color-success">Approved</div>
-    <ng-container *ngIf="claim?.isPendingSync">
+    <ng-container *ngIf="claim?.canPublishClaim">
       <div>
         <ng-content></ng-content>
       </div>

--- a/src/app/routes/enrolment/models/enrolment-claim.spec.ts
+++ b/src/app/routes/enrolment/models/enrolment-claim.spec.ts
@@ -283,6 +283,68 @@ describe('EnrolmentClaim tests', () => {
       ).toBeFalse();
     });
   });
+  describe('canPublishClaim', () => {
+    it('should return true if claim is not synced and claim is not expired', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          registrationTypes: [RegistrationTypes.OnChain],
+          expirationTimestamp: (Date.now() + 500000).toString(),
+        } as Claim).canPublishClaim
+      ).toBeTrue();
+    });
+    it('should return false if claim is not synced and claim IS expired', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          registrationTypes: [RegistrationTypes.OnChain],
+          expirationTimestamp: (Date.now() - 500).toString(),
+        } as Claim).canPublishClaim
+      ).toBeFalse();
+    });
+    it('should return false if claim IS synced and claim is not expired', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          registrationTypes: [RegistrationTypes.OffChain],
+          expirationTimestamp: (Date.now() + 5000).toString(),
+        } as Claim).setIsSyncedOffChain(true).canPublishClaim
+      ).toBeFalse();
+    });
+    it('should return false if claim IS synced and claim IS expired', () => {
+      expect(
+        new EnrolmentClaim({
+          isAccepted: true,
+          registrationTypes: [RegistrationTypes.OffChain],
+          expirationTimestamp: (Date.now() - 50).toString(),
+        } as Claim).setIsSyncedOffChain(true).canPublishClaim
+      ).toBeFalse();
+    });
+  });
+
+  describe('isExpired', () => {
+    it('should return true if claim expiration timestamp is in the past', () => {
+      expect(
+        new EnrolmentClaim({
+          expirationTimestamp: (Date.now() - 500).toString(),
+        } as Claim).isExpired
+      ).toBeTrue();
+    });
+    it('should return false if claim expiration timestamp is in the future', () => {
+      expect(
+        new EnrolmentClaim({
+          expirationTimestamp: (Date.now() + 5000).toString(),
+        } as Claim).isExpired
+      ).toBeFalse();
+    });
+    it('should return false if there is no timestamp', () => {
+      expect(
+        new EnrolmentClaim({
+          expirationTimestamp: null,
+        } as Claim).isExpired
+      ).toBeFalse();
+    });
+  });
 
   describe('isRevoked', () => {
     it('should return true if is revoked only off chain', () => {
@@ -414,7 +476,7 @@ describe('EnrolmentClaim tests', () => {
           claimType: `role.${NamespaceType.Role}.test.iam.ewc`,
           expirationTimestamp: null,
         } as Claim).expirationStatus
-      ).toEqual('');
+      ).toEqual(undefined);
     });
     it('should have an exporation date if there expiration timestamp', () => {
       expect(

--- a/src/app/routes/enrolment/models/enrolment-claim.ts
+++ b/src/app/routes/enrolment/models/enrolment-claim.ts
@@ -50,6 +50,17 @@ export class EnrolmentClaim
     return !this.iclClaim?.isAccepted && !this.iclClaim?.isRejected;
   }
 
+  get isExpired() {
+    return (
+      !!this.iclClaim.expirationTimestamp &&
+      parseInt(this.iclClaim.expirationTimestamp) < Date.now()
+    );
+  }
+
+  get canPublishClaim() {
+    return this.isPendingSync && !this.isExpired;
+  }
+
   get isPendingSync() {
     if (this.isRegisteredOnChain() && this.isRegisteredOffChain()) {
       return !this.isSyncedOffChain || !this.isSyncedOnChain;
@@ -196,12 +207,11 @@ export class EnrolmentClaim
 
   private defineExpirationStatus() {
     if (!this.iclClaim.expirationTimestamp) {
-      this.expirationStatus = '';
+      this.expirationStatus = undefined;
     } else {
-      this.expirationStatus =
-        parseInt(this.iclClaim.expirationTimestamp) < Date.now()
-          ? ExpirationStatus.EXPIRED
-          : ExpirationStatus.NOT_EXPIRED;
+      this.expirationStatus = this.isExpired
+        ? ExpirationStatus.EXPIRED
+        : ExpirationStatus.NOT_EXPIRED;
     }
   }
 


### PR DESCRIPTION

- create getter (canPublishClaim) to determine if "Publish" button should be shown for pending claims on My Enrolments tab
- Add unit tests for isExpired and canPublishClaim getter