### PR TITLE
fix(exp): use undefined vs null if no expirationTimestamp

### DIFF
--- a/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
+++ b/src/app/routes/enrolment/view-requests/issuer-requests/issuer-requests.component.ts
@@ -88,7 +88,7 @@ export class IssuerRequestsComponent
   }
 
   clearExpirationDate(): void {
-    this.expirationTime = null;
+    this.expirationTime = undefined;
   }
 
   private getRoleIssuerFields(namespace: string): void {
@@ -98,7 +98,7 @@ export class IssuerRequestsComponent
         this.roleDefinition = definitions;
         this.expirationTime = this.roleDefinition?.defaultValidityPeriod
           ? Date.now() + this.roleDefinition?.defaultValidityPeriod
-          : null;
+          : undefined;
       });
   }
 }


### PR DESCRIPTION
- ICL is expecting undefined or number for expirationTimestamp. In keeping with the expected types, just changing this to undefined from 'null' if no value. 
- As one step further, we could not add expirationTimestamp to the request object to ICL if timestamp is undefined...