### PR TITLE
fix(exp): have validity period components accept miliseconds

### DIFF
--- a/src/app/routes/applications/new-role/components/validity-period/validity-period.component.spec.ts
+++ b/src/app/routes/applications/new-role/components/validity-period/validity-period.component.spec.ts
@@ -44,7 +44,7 @@ describe('ValidityPeriodComponent', () => {
   });
 
   it('should update input with provided value', () => {
-    component.validityPeriod = 135;
+    component.validityPeriod = 120015;
     fixture.detectChanges();
 
     const { yearsInput, daysInput, hoursInput, minutesInput, secondsInput } =
@@ -74,7 +74,7 @@ describe('ValidityPeriodComponent', () => {
     periodNext.click();
     fixture.detectChanges();
 
-    expect(nextSpy).toHaveBeenCalledWith(100000);
+    expect(nextSpy).toHaveBeenCalledWith(60040);
   });
 
   it('should return 10 minutes when passing object contains only minutes', () => {
@@ -93,7 +93,7 @@ describe('ValidityPeriodComponent', () => {
   });
 
   it('should update inputs while containing only minutes', () => {
-    component.validityPeriod = 600;
+    component.validityPeriod = 600000;
     fixture.detectChanges();
 
     const { yearsInput, daysInput, hoursInput, minutesInput, secondsInput } =

--- a/src/app/routes/applications/new-role/components/validity-period/validity-period.component.ts
+++ b/src/app/routes/applications/new-role/components/validity-period/validity-period.component.ts
@@ -41,7 +41,6 @@ export class ValidityPeriodComponent {
       return;
     }
     const theValue = new Timestamp().parseToMilliseconds(this.form.value);
-    console.log(theValue, 'THE VALUE');
     this.next.emit(theValue);
   }
 }

--- a/src/app/routes/applications/new-role/components/validity-period/validity-period.component.ts
+++ b/src/app/routes/applications/new-role/components/validity-period/validity-period.component.ts
@@ -20,7 +20,7 @@ export class ValidityPeriodComponent {
       return;
     }
     this.form.setValue({
-      ...new Timestamp().determineFromSeconds(value),
+      ...new Timestamp().determineFromMiliseconds(value),
     });
   }
   @Output() next = new EventEmitter<number | undefined>();
@@ -40,6 +40,8 @@ export class ValidityPeriodComponent {
     if (this.form.invalid) {
       return;
     }
-    this.next.emit(new Timestamp().parseToMilliseconds(this.form.value));
+    const theValue = new Timestamp().parseToMilliseconds(this.form.value);
+    console.log(theValue, 'THE VALUE');
+    this.next.emit(theValue);
   }
 }

--- a/src/app/routes/enrolment/view-requests/components/expiration-info/expiration-info.component.html
+++ b/src/app/routes/enrolment/view-requests/components/expiration-info/expiration-info.component.html
@@ -1,12 +1,12 @@
 <app-report-problem>
   <!-- SECTION 1 -->
   <ng-container *ngIf="defaultValidityPeriod">
-    The default validity period for this role is <b>{{ defaultValidityPeriod / 1000 | timeDuration }}</b
+    The default validity period for this role is <b>{{ defaultValidityPeriod | timeDuration }}</b
     >.<br
   /></ng-container>
   <ng-container *ngIf="defaultValidityPeriod">
     The calculated <b>default expiration date</b> for this role is
-    <b>{{ defaultValidityPeriod / 1000 | timeShift | defaultDate }} UTC</b>.<br />
+    <b>{{ defaultValidityPeriod | timeShift | defaultDate }} UTC</b>.<br />
     <br />
     To override this date, use the date picker below.<br />
     To remove the expiration date, click 'Remove Expiration Date'.<br />
@@ -22,7 +22,7 @@
   <ng-container *ngIf="(!removeExpDate && defaultValidityPeriod) || expirationTime">
     <br />
     This role will now be issued with an expiration date of
-    <b>{{ expirationTime / 1000 || defaultValidityPeriod / 1000 | timeShift | defaultDate }} UTC</b>
+    <b>{{ expirationTime || defaultValidityPeriod | timeShift | defaultDate }} UTC</b>
   </ng-container>
   <ng-container *ngIf="removeExpDate || (!defaultValidityPeriod && !expirationTime)">
     <br />

--- a/src/app/shared/pipes/time-duration/time-duration.pipe.spec.ts
+++ b/src/app/shared/pipes/time-duration/time-duration.pipe.spec.ts
@@ -37,7 +37,7 @@ describe('time-duration', () => {
   });
 
   it('should return 2 minutes', () => {
-    expect(pipe.transform(2 * 60000)).toEqual('2 minutes');
+    expect(pipe.transform(2 * MINUTE_IN_MILISECONDS)).toEqual('2 minutes');
   });
 
   it('should return 2 days and 3 hours', () => {

--- a/src/app/shared/pipes/time-duration/time-duration.pipe.spec.ts
+++ b/src/app/shared/pipes/time-duration/time-duration.pipe.spec.ts
@@ -1,9 +1,9 @@
 import { TimeDurationPipe } from './time-duration.pipe';
 
-const YEAR_IN_SECONDS = 31536000;
-const DAY_IN_SECONDS = 86400;
-const HOUR_IN_SECONDS = 3600;
-const MINUTE_IN_SECONDS = 60;
+const YEAR_IN_MILISECONDS = 31536000 * 1000;
+const DAY_IN_MILISECONDS = 86400 * 1000;
+const HOUR_IN_MILISECONDS = 3600 * 1000;
+const MINUTE_IN_MILISECONDS = 60000;
 
 describe('time-duration', () => {
   let pipe: TimeDurationPipe;
@@ -17,39 +17,41 @@ describe('time-duration', () => {
   });
 
   it('should return 1 day', () => {
-    expect(pipe.transform(DAY_IN_SECONDS)).toEqual('1 day');
+    expect(pipe.transform(DAY_IN_MILISECONDS)).toEqual('1 day');
   });
 
   it('should return 1 year', () => {
-    expect(pipe.transform(YEAR_IN_SECONDS)).toEqual('1 year');
+    expect(pipe.transform(YEAR_IN_MILISECONDS)).toEqual('1 year');
   });
 
   it('should return 2 days', () => {
-    expect(pipe.transform(2 * DAY_IN_SECONDS)).toEqual('2 days');
+    expect(pipe.transform(2 * DAY_IN_MILISECONDS)).toEqual('2 days');
   });
 
   it('should return 1 hour', () => {
-    expect(pipe.transform(HOUR_IN_SECONDS)).toEqual('1 hour');
+    expect(pipe.transform(HOUR_IN_MILISECONDS)).toEqual('1 hour');
   });
 
   it('should return 2 hours', () => {
-    expect(pipe.transform(2 * HOUR_IN_SECONDS)).toEqual('2 hours');
+    expect(pipe.transform(2 * HOUR_IN_MILISECONDS)).toEqual('2 hours');
   });
 
   it('should return 2 minutes', () => {
-    expect(pipe.transform(2 * MINUTE_IN_SECONDS)).toEqual('2 minutes');
+    expect(pipe.transform(2 * 60000)).toEqual('2 minutes');
   });
 
   it('should return 2 days and 3 hours', () => {
-    expect(pipe.transform(2 * DAY_IN_SECONDS + 3 * HOUR_IN_SECONDS)).toEqual(
-      '2 days and 3 hours'
-    );
+    expect(
+      pipe.transform(2 * DAY_IN_MILISECONDS + 3 * HOUR_IN_MILISECONDS)
+    ).toEqual('2 days and 3 hours');
   });
 
   it('should return 2 days, 3 hours and 5 minutes', () => {
     expect(
       pipe.transform(
-        2 * DAY_IN_SECONDS + 3 * HOUR_IN_SECONDS + 5 * MINUTE_IN_SECONDS
+        2 * DAY_IN_MILISECONDS +
+          3 * HOUR_IN_MILISECONDS +
+          5 * MINUTE_IN_MILISECONDS
       )
     ).toEqual('2 days, 3 hours and 5 minutes');
   });
@@ -57,7 +59,10 @@ describe('time-duration', () => {
   it('should return 2 days, 3 hours, 5 minutes and 32 seconds', () => {
     expect(
       pipe.transform(
-        2 * DAY_IN_SECONDS + 3 * HOUR_IN_SECONDS + 5 * MINUTE_IN_SECONDS + 32
+        2 * DAY_IN_MILISECONDS +
+          3 * HOUR_IN_MILISECONDS +
+          5 * MINUTE_IN_MILISECONDS +
+          32
       )
     ).toEqual('2 days, 3 hours, 5 minutes and 32 seconds');
   });
@@ -65,10 +70,10 @@ describe('time-duration', () => {
   it('should return 1 year, 2 days, 3 hours, 5 minutes and 32 seconds', () => {
     expect(
       pipe.transform(
-        YEAR_IN_SECONDS +
-          2 * DAY_IN_SECONDS +
-          3 * HOUR_IN_SECONDS +
-          5 * MINUTE_IN_SECONDS +
+        YEAR_IN_MILISECONDS +
+          2 * DAY_IN_MILISECONDS +
+          3 * HOUR_IN_MILISECONDS +
+          5 * MINUTE_IN_MILISECONDS +
           32
       )
     ).toEqual('1 year, 2 days, 3 hours, 5 minutes and 32 seconds');
@@ -76,7 +81,7 @@ describe('time-duration', () => {
 
   it('should return 5 hours, 3 minutes and 1 second', () => {
     expect(
-      pipe.transform(5 * HOUR_IN_SECONDS + 3 * MINUTE_IN_SECONDS + 1)
+      pipe.transform(5 * HOUR_IN_MILISECONDS + 3 * MINUTE_IN_MILISECONDS + 1)
     ).toEqual('5 hours, 3 minutes and 1 second');
   });
 

--- a/src/app/shared/pipes/time-duration/time-duration.pipe.ts
+++ b/src/app/shared/pipes/time-duration/time-duration.pipe.ts
@@ -12,7 +12,9 @@ export class TimeDurationPipe implements PipeTransform {
       return this.defaultText;
     }
     if (typeof value === 'number') {
-      return this.createMessage(new Timestamp().determineFromSeconds(value));
+      return this.createMessage(
+        new Timestamp().determineFromMiliseconds(value)
+      );
     }
 
     return this.createMessage(value);

--- a/src/app/shared/pipes/time-duration/timestamp.ts
+++ b/src/app/shared/pipes/time-duration/timestamp.ts
@@ -7,12 +7,15 @@ export interface ParseTimestampResult {
 }
 
 export class Timestamp {
-  private readonly minute = 60;
+  /*
+   The base unit for all time calculations is miliseconds
+  */
+  private readonly minute = 60 * 1000; //60 seconds = 60000 miliseconds
   private readonly hour = this.minute * 60;
   private readonly day = this.hour * 24;
   private readonly year = this.day * 365;
 
-  determineFromSeconds(value: number): ParseTimestampResult {
+  determineFromMiliseconds(value: number): ParseTimestampResult {
     const years = this.getQuotient(value, this.year);
     const yearsRemainder = this.getRemainder(value, this.year);
     const days = this.getQuotient(yearsRemainder, this.day);
@@ -24,7 +27,7 @@ export class Timestamp {
     return { years, days, hours, minutes, seconds };
   }
 
-  parseToSeconds(value: ParseTimestampResult): number {
+  parseToMilliseconds(value: ParseTimestampResult): number {
     if (Object.values(value).every((val) => val === 0)) {
       return null;
     }
@@ -35,11 +38,6 @@ export class Timestamp {
       this.multiply(value.minutes, this.minute) +
       value.seconds
     );
-  }
-
-  parseToMilliseconds(value: ParseTimestampResult): number {
-    const seconds = this.parseToSeconds(value);
-    return seconds ? seconds * 1000 : null;
   }
 
   private multiply(multiplicand: number, multiplier: number) {

--- a/src/app/shared/pipes/time-shift/time-shift.pipe.spec.ts
+++ b/src/app/shared/pipes/time-shift/time-shift.pipe.spec.ts
@@ -18,7 +18,7 @@ describe('TimeShiftPipe', () => {
 
   it('should return date shifted for 100 seconds', () => {
     const exampleDate = new Date('2014-01-01 10:11:55');
-    expect(pipe.transform(100, exampleDate)).toEqual(
+    expect(pipe.transform(100000, exampleDate)).toEqual(
       new Date('2014-01-01 10:13:35')
     );
   });

--- a/src/app/shared/pipes/time-shift/time-shift.pipe.ts
+++ b/src/app/shared/pipes/time-shift/time-shift.pipe.ts
@@ -8,7 +8,7 @@ export class TimeShiftPipe implements PipeTransform {
 
   transform(shift: number, dateValue?: string | Date): Date {
     const date = this.getDate(dateValue);
-    date.setSeconds(date.getSeconds() + shift);
+    date.setMilliseconds(date.getMilliseconds() + shift);
     return date;
   }
 


### PR DESCRIPTION
This addresses https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54?selectedIssue=SWTCH-1389
- The fundamental issue was the validity period component was relying on seconds after the validity period (after clicking "Next" on new role form) was converted to milliseconds. As a result, if you input a validity period, clicked "next" and then clicked "back", the input fields did not have the correct numbers. 
- As a fix, I have this component now accepting milliseconds. There is no instance in any of the validity or expiration components where seconds are being used now. Everything is now using milliseconds only. I think this makes things easier as we don't have to divide by 1000 anywhere etc. 

I will test this more. 