### PR TITLE
Fix unable to complete login signature

### DIFF
--- a/src/app/routes/dashboard/dashboard.component.spec.ts
+++ b/src/app/routes/dashboard/dashboard.component.spec.ts
@@ -66,12 +66,6 @@ describe('DashboardComponent', () => {
     );
   });
 
-  it('should call reinitialize action', () => {
-    setUp();
-    fixture.detectChanges();
-    expect(dispatchSpy).toHaveBeenCalledWith(AuthActions.reinitializeAuth());
-  });
-
   it('should check if searching through apps and orgs', () => {
     expect(component.searchBy().length).toEqual(2);
     expect(component.searchBy()).toEqual([SearchType.App, SearchType.Org]);

--- a/src/app/routes/dashboard/dashboard.component.ts
+++ b/src/app/routes/dashboard/dashboard.component.ts
@@ -36,7 +36,6 @@ export class DashboardComponent implements AfterViewInit {
       .subscribe((redirectUrl) => {
         this.store.dispatch(LayoutActions.setRedirectUrl({ url: redirectUrl }));
       });
-    this.store.dispatch(AuthActions.reinitializeAuth());
   }
 
   searchBy() {

--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -527,8 +527,6 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
   private async initLoginUser() {
     // Check Login
     if (this.loginService.isSessionActive()) {
-      this.store.dispatch(AuthActions.reinitializeAuthForEnrol());
-      // Set Loggedin Flag to true
       this.isLoggedIn = await this.store
         .select(isUserLoggedIn)
         .pipe(filter<boolean>(Boolean), take(1))

--- a/src/app/routes/verifiable-presentation/verifiable-presentation/verifiable-presentation.component.ts
+++ b/src/app/routes/verifiable-presentation/verifiable-presentation/verifiable-presentation.component.ts
@@ -83,7 +83,6 @@ export class VerifiablePresentationComponent implements OnInit {
   private async initLoginUser() {
     // Check Login
     if (this.loginService.isSessionActive()) {
-      this.store.dispatch(AuthActions.reinitializeAuthForEnrol());
       // Set Loggedin Flag to true
       this.isLoggedIn = await this.store
         .select(isUserLoggedIn)

--- a/src/app/shared/services/env/env.service.ts
+++ b/src/app/shared/services/env/env.service.ts
@@ -9,7 +9,6 @@ export class EnvService {
 
   cacheServerUrl = environment.cacheServerUrl;
   natsServerUrl = environment.natsServerUrl;
-  kmsServerUrl = environment.kmsServerUrl;
   ekcUrl = environment.ekcUrl;
   showAzureLoginOption: boolean = environment.showAzureLoginOption;
   natsEnvironmentName: string = environment.natsEnvironmentName;

--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -199,7 +199,6 @@ export class IamService {
         connected: false,
         userClosedModal: e.message === 'User closed modal',
         realtimeExchangeConnected: false,
-        accountInfo: undefined,
         message: e.message,
       };
     }
@@ -208,7 +207,6 @@ export class IamService {
       connected: true,
       userClosedModal: false,
       realtimeExchangeConnected: true,
-      accountInfo: this.signerService.accountInfo,
     };
   }
 

--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -271,8 +271,6 @@ export class IamService {
         return initWithMetamask();
       case ProviderType.WalletConnect:
         return initWithWalletConnect();
-      case ProviderType.EwKeyManager:
-        return initWithKms({ kmsServerUrl: this.envService.kmsServerUrl });
       case ProviderType.PrivateKey:
         return initWithPrivateKeySigner(
           localStorage.getItem('PrivateKey'),

--- a/src/app/shared/services/login/login.service.spec.ts
+++ b/src/app/shared/services/login/login.service.spec.ts
@@ -118,5 +118,4 @@ describe('LoginService', () => {
         );
       });
   });
-
 });

--- a/src/app/shared/services/login/login.service.spec.ts
+++ b/src/app/shared/services/login/login.service.spec.ts
@@ -67,7 +67,7 @@ describe('LoginService', () => {
       const getSpy = jasmine.createSpy().and.returnValue(ProviderType.MetaMask);
       Object.defineProperty(IamService, 'providerType', { get: getSpy });
 
-      from(service.login()).subscribe(({ success }) => {
+      service.login().subscribe(({ success }) => {
         expect(success).toBe(true);
       });
     })

--- a/src/app/shared/services/login/login.service.spec.ts
+++ b/src/app/shared/services/login/login.service.spec.ts
@@ -118,4 +118,5 @@ describe('LoginService', () => {
         );
       });
   });
+
 });

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -3,7 +3,6 @@ import { IamService, PROVIDER_TYPE } from '../iam.service';
 import { LoadingService } from '../loading.service';
 import { ToastrService } from 'ngx-toastr';
 import {
-  AccountInfo,
   IS_ETH_SIGNER,
   ProviderType,
   PUBLIC_KEY,
@@ -107,7 +106,7 @@ export class LoginService {
   login(
     loginOptions?: LoginOptions,
     redirectOnChange = true
-  ): Observable<{ success: boolean; accountInfo?: AccountInfo | undefined }> {
+  ): Observable<{ success: boolean; }> {
     this.waitForSignature(redirectOnChange);
     return this.initialize(loginOptions, redirectOnChange);
   }
@@ -115,7 +114,7 @@ export class LoginService {
   reinitialize(
     loginOptions?: LoginOptions,
     redirectOnChange = true
-  ): Observable<{ success: boolean; accountInfo?: AccountInfo | undefined }> {
+  ): Observable<{ success: boolean; }> {
     this.loadingService.show();
     this.createTimer(1, redirectOnChange);
     return this.initialize(loginOptions, redirectOnChange);
@@ -123,7 +122,7 @@ export class LoginService {
 
   private initialize(loginOptions?: LoginOptions, redirectOnChange = true) {
     return from(this.iamService.initializeConnection(loginOptions)).pipe(
-      map(({ did, connected, userClosedModal, accountInfo }) => {
+      map(({ did, connected, userClosedModal }) => {
         const loginSuccessful = did && connected && !userClosedModal;
         if (loginSuccessful) {
           this.iamListenerService.setListeners((config) =>
@@ -140,7 +139,7 @@ export class LoginService {
             redirectOnChange
           );
         }
-        return { success: Boolean(loginSuccessful), accountInfo };
+        return { success: Boolean(loginSuccessful) };
       }),
       delayWhen(({ success }) => {
         if (success) return this.storeSession();

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -17,9 +17,7 @@ import {
   filter,
   map,
   share,
-  switchMap,
   take,
-  tap,
 } from 'rxjs/operators';
 import { swalLoginError } from './helpers/swal-login-error-handler';
 import { LoginSwalButtons } from './helpers/login-swal.buttons';
@@ -165,39 +163,21 @@ export class LoginService {
     navigateOnTimeout = true
   ) {
     this._throwTimeoutError = false;
-    const timeoutInMinutes =
-      walletProvider === ProviderType.EwKeyManager ? 2 : 1;
-    const connectionMessage = isConnectAndSign
-      ? 'connection to a wallet and '
-      : '';
+    const timeoutInMinutes = 1;
+    const connectionMessage = 'connection to a wallet and ';
     const messages = [
       {
         message: `Your ${connectionMessage}signature is being requested.`,
-        relevantProviders: 'all',
       },
       {
-        message:
-          'EW Key Manager should appear in a new browser tab or window. If you do not see it, please check your browser settings.',
-        relevantProviders: ProviderType.EwKeyManager,
-      },
-      {
-        message: `If you do not complete this within ${timeoutInMinutes} minute${
-          timeoutInMinutes === 1 ? '' : 's'
-        },
-          your browser will refresh automatically.`,
-        relevantProviders: 'all',
+        message: `If you do not complete this within ${timeoutInMinutes} minute your browser will refresh automatically.`,
       },
     ];
     const waitForSignatureMessage = messages
-      .filter(
-        (m) =>
-          m.relevantProviders === walletProvider ||
-          m.relevantProviders === 'all'
-      )
       .map((m) => m.message);
     this.loadingService.show(waitForSignatureMessage);
     this._timer = setTimeout(() => {
-      this._displayTimeout(isConnectAndSign, navigateOnTimeout);
+      this._displayTimeout(navigateOnTimeout);
       this.clearWaitSignatureTimer();
       this._throwTimeoutError = true;
     }, timeoutInMinutes * 60000);
@@ -207,6 +187,7 @@ export class LoginService {
     clearTimeout(this._timer);
     this._timer = undefined;
     this.loadingService.hide();
+    // this.clearSession();
 
     if (this._throwTimeoutError) {
       this._throwTimeoutError = false;
@@ -296,19 +277,15 @@ export class LoginService {
       encodeURIComponent(this._deepLink);
   }
 
-  private async _displayTimeout(
-    isConnectAndSign?: boolean,
+  private _displayTimeout(
     navigateOnTimeout?: boolean
   ) {
-    let message = 'sign';
-    if (isConnectAndSign) {
-      message = 'connect with your wallet and sign';
-    }
+    let message = 'connect with your wallet and sign';
+
     const config = {
       title: 'Wallet Signature Timeout',
       text: `The period to ${message} the requested signature has elapsed. Please login again.`,
       icon: 'error',
-      button: 'Proceed',
       closeOnClickOutside: false,
     };
 

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -2,11 +2,7 @@ import { Injectable } from '@angular/core';
 import { IamService, PROVIDER_TYPE } from '../iam.service';
 import { LoadingService } from '../loading.service';
 import { ToastrService } from 'ngx-toastr';
-import {
-  IS_ETH_SIGNER,
-  ProviderType,
-  PUBLIC_KEY,
-} from 'iam-client-lib';
+import { IS_ETH_SIGNER, ProviderType, PUBLIC_KEY } from 'iam-client-lib';
 import SWAL from 'sweetalert';
 import { from, Observable, of } from 'rxjs';
 import { IamListenerService } from '../iam-listener/iam-listener.service';
@@ -106,7 +102,7 @@ export class LoginService {
   login(
     loginOptions?: LoginOptions,
     redirectOnChange = true
-  ): Observable<{ success: boolean; }> {
+  ): Observable<{ success: boolean }> {
     this.waitForSignature(redirectOnChange);
     return this.initialize(loginOptions, redirectOnChange);
   }
@@ -114,7 +110,7 @@ export class LoginService {
   reinitialize(
     loginOptions?: LoginOptions,
     redirectOnChange = true
-  ): Observable<{ success: boolean; }> {
+  ): Observable<{ success: boolean }> {
     this.loadingService.show();
     this.createTimer(1, redirectOnChange);
     return this.initialize(loginOptions, redirectOnChange);

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -30,7 +30,9 @@ export const setProvider = createAction(
 
 export const reinitializeAuth = createAction('[AUTH] Reinitialize Logged User');
 
-export const reinitializeAuthWithMetamask = createAction('[AUTH] Reinitialize Logged User With Metamask');
+export const reinitializeAuthWithMetamask = createAction(
+  '[AUTH] Reinitialize Logged User With Metamask'
+);
 
 export const logout = createAction('[AUTH] Logout');
 

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -17,9 +17,7 @@ export const welcomeLogin = createAction(
 
 export const openLoginDialog = createAction('[AUTH] Open Login Dialog');
 
-export const loginSuccess = createAction(
-  '[AUTH] User Login Success',
-);
+export const loginSuccess = createAction('[AUTH] User Login Success');
 export const loginFailure = createAction('[AUTH] User Login Failure');
 
 export const setProvider = createAction(
@@ -27,7 +25,9 @@ export const setProvider = createAction(
   props<{ walletProvider: ProviderType }>()
 );
 
-export const reinitializeAuthWithoutMetamask = createAction('[AUTH] Reinitialize Logged User Without Metamask');
+export const reinitializeAuthWithoutMetamask = createAction(
+  '[AUTH] Reinitialize Logged User Without Metamask'
+);
 
 export const reinitializeAuthWithMetamask = createAction(
   '[AUTH] Reinitialize Logged User With Metamask'

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -30,6 +30,8 @@ export const setProvider = createAction(
 
 export const reinitializeAuth = createAction('[AUTH] Reinitialize Logged User');
 
+export const reinitializeAuthWithMetamask = createAction('[AUTH] Reinitialize Logged User With Metamask');
+
 export const logout = createAction('[AUTH] Logout');
 
 export const logoutWithRedirectUrl = createAction(

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -27,7 +27,7 @@ export const setProvider = createAction(
   props<{ walletProvider: ProviderType }>()
 );
 
-export const reinitializeAuth = createAction('[AUTH] Reinitialize Logged User');
+export const reinitializeAuthWithoutMetamask = createAction('[AUTH] Reinitialize Logged User Without Metamask');
 
 export const reinitializeAuthWithMetamask = createAction(
   '[AUTH] Reinitialize Logged User With Metamask'

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -30,18 +30,10 @@ export const setProvider = createAction(
 
 export const reinitializeAuth = createAction('[AUTH] Reinitialize Logged User');
 
-export const reinitializeAuthForEnrol = createAction(
-  '[AUTH] Reinitialize Logged User For Enrol Page'
-);
-
 export const logout = createAction('[AUTH] Logout');
 
 export const logoutWithRedirectUrl = createAction(
   '[AUTH] Logout With Redirect URL'
-);
-
-export const getMetamaskOptions = createAction(
-  '[AUTH] Get Metamask Login Options'
 );
 
 export const setMetamaskLoginOptions = createAction(

--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -19,7 +19,6 @@ export const openLoginDialog = createAction('[AUTH] Open Login Dialog');
 
 export const loginSuccess = createAction(
   '[AUTH] User Login Success',
-  props<{ accountInfo: AccountInfo }>()
 );
 export const loginFailure = createAction('[AUTH] User Login Failure');
 

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { of, ReplaySubject, throwError } from 'rxjs';
 
@@ -32,7 +32,6 @@ describe('AuthEffects', () => {
 
   beforeEach(() => {
     loginServiceSpy = jasmine.createSpyObj('LoginService', [
-      'waitForSignature',
       'login',
       'disconnect',
       'isSessionActive',
@@ -155,23 +154,19 @@ describe('AuthEffects', () => {
       );
       loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
 
-      effects.loginViaDialog$
-        .subscribe((resultAction) => {
-          expect(loginServiceSpy.login).toHaveBeenCalledWith(
-            {
-              providerType: ProviderType.MetaMask,
-              reinitializeMetamask: true,
-            },
-            undefined
-          );
-          expect(loginServiceSpy.waitForSignature).toHaveBeenCalled();
-          expect(resultAction).toEqual(
-            AuthActions.loginSuccess({ accountInfo })
-          );
-          expect(dialogSpy.closeAll).toHaveBeenCalled();
+      effects.loginViaDialog$.subscribe((resultAction) => {
+        expect(loginServiceSpy.login).toHaveBeenCalledWith(
+          {
+            providerType: ProviderType.MetaMask,
+            reinitializeMetamask: true,
+          },
+          undefined
+        );
+        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        expect(dialogSpy.closeAll).toHaveBeenCalled();
 
-          done();
-        });
+        done();
+      });
     });
 
     it('should do not close dialog and return login failure action on login failure', (done) => {
@@ -180,13 +175,11 @@ describe('AuthEffects', () => {
       );
       loginServiceSpy.login.and.returnValue(of(false));
 
-      effects.loginViaDialog$
-        .subscribe((resultAction) => {
-          expect(loginServiceSpy.waitForSignature).toHaveBeenCalled();
-          expect(resultAction).toEqual(AuthActions.loginFailure());
+      effects.loginViaDialog$.subscribe((resultAction) => {
+        expect(resultAction).toEqual(AuthActions.loginFailure());
 
-          done();
-        });
+        done();
+      });
     });
 
     it('should do not close dialog and return login failure action when login throws error', (done) => {
@@ -198,24 +191,6 @@ describe('AuthEffects', () => {
       effects.loginViaDialog$.subscribe((resultAction) => {
         expect(resultAction).toEqual(AuthActions.loginFailure());
 
-        done();
-      });
-    });
-
-    it('should call waitForSignature with metamask and not navigate on timeout option', (done) => {
-      actions$.next(
-        AuthActions.loginViaDialog({
-          provider: ProviderType.MetaMask,
-          navigateOnTimeout: false,
-        })
-      );
-      loginServiceSpy.login.and.returnValue(of({ success: true }));
-
-      effects.loginViaDialog$.subscribe(() => {
-        expect(loginServiceSpy.waitForSignature).toHaveBeenCalledWith(
-          ProviderType.MetaMask,
-          false
-        );
         done();
       });
     });
@@ -280,7 +255,6 @@ describe('AuthEffects', () => {
             providerType: ProviderType.MetaMask,
             reinitializeMetamask: true,
           });
-          expect(loginServiceSpy.waitForSignature).toHaveBeenCalled();
           expect(resultAction).toEqual(
             AuthActions.loginSuccess({ accountInfo })
           );
@@ -302,21 +276,17 @@ describe('AuthEffects', () => {
       };
       loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
 
-      effects.welcomePageLogin$
-        .subscribe((resultAction) => {
-          expect(loginServiceSpy.login).toHaveBeenCalledWith({
-            providerType: ProviderType.MetaMask,
-            reinitializeMetamask: true,
-          });
-          expect(loginServiceSpy.waitForSignature).toHaveBeenCalled();
-          expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(
-            `/${RouterConst.ReturnUrl}`
-          );
-          expect(resultAction).toEqual(
-            AuthActions.loginSuccess({ accountInfo })
-          );
-          done();
+      effects.welcomePageLogin$.subscribe((resultAction) => {
+        expect(loginServiceSpy.login).toHaveBeenCalledWith({
+          providerType: ProviderType.MetaMask,
+          reinitializeMetamask: true,
         });
+        expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(
+          `/${RouterConst.ReturnUrl}`
+        );
+        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        done();
+      });
     });
 
     it('should return failure action when login fails', (done) => {
@@ -340,7 +310,7 @@ describe('AuthEffects', () => {
       actions$ = new ReplaySubject(1);
     });
 
-    it('should return failure action when reinitialization fails', fakeAsync((done) => {
+    it('should return failure action when reinitialization fails', (done) => {
       actions$.next(AuthActions.reinitializeAuth());
       loginServiceSpy.isSessionActive.and.returnValue(true);
       store.overrideSelector(AuthSelectors.isUserLoggedIn, false);
@@ -351,14 +321,11 @@ describe('AuthEffects', () => {
         publicKey: 'key',
       });
 
-      tick(100);
-
       effects.reinitializeLoggedUserWithMetamask$.subscribe((resultAction) => {
         expect(resultAction).toEqual(AuthActions.loginFailure());
-        flush();
         done();
       });
-    }));
+    });
 
     it('should return success action when reinitialization completes successfully', (done) => {
       actions$.next(AuthActions.reinitializeAuth());
@@ -388,7 +355,7 @@ describe('AuthEffects', () => {
       loginServiceSpy.isSessionActive.and.returnValue(false);
 
       effects.reinitializeLoggedUserWithMetamask$.subscribe();
-      expect(loginServiceSpy.login).not.toHaveBeenCalled()
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
       done();
     });
 
@@ -440,7 +407,7 @@ describe('AuthEffects', () => {
       effects.reinitializeLoggedUserWithMetamask$.subscribe();
       expect(loginServiceSpy.login).not.toHaveBeenCalled();
       done();
-    })
+    });
   });
 
   describe('reinitializeLoggedUser$', () => {
@@ -491,7 +458,7 @@ describe('AuthEffects', () => {
       loginServiceSpy.isSessionActive.and.returnValue(false);
 
       effects.reinitializeLoggedUser$.subscribe();
-      expect(loginServiceSpy.login).not.toHaveBeenCalled()
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
       done();
     });
 
@@ -525,7 +492,7 @@ describe('AuthEffects', () => {
       effects.reinitializeLoggedUser$.subscribe();
       expect(loginServiceSpy.login).not.toHaveBeenCalled();
       done();
-    })
+    });
   });
 
   describe('setWalletProviderAfterLogin$', () => {

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -225,7 +225,6 @@ describe('AuthEffects', () => {
       effects.loginViaDialog$.subscribe(() => {
         expect(loginServiceSpy.waitForSignature).toHaveBeenCalledWith(
           ProviderType.MetaMask,
-          true,
           false
         );
         done();
@@ -353,6 +352,111 @@ describe('AuthEffects', () => {
     });
   });
 
+  describe('reinitializeLoggedUserWithMetamask$', () => {
+    beforeEach(() => {
+      actions$ = new ReplaySubject(1);
+    });
+
+    it('should return failure action when reinitialization fails', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+      store.overrideSelector(AuthSelectors.isUserLoggedIn, false);
+      store.overrideSelector(AuthSelectors.isMetamaskDisabled, false);
+      loginServiceSpy.login.and.returnValue(of(false));
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.MetaMask,
+        publicKey: 'key',
+      });
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe((resultAction) => {
+        expect(resultAction).toEqual(AuthActions.loginFailure());
+        done();
+      });
+    });
+
+    it('should return success action when reinitialization completes successfully', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+      const accountInfo = {
+        chainName: 'chainName',
+        chainId: 123,
+        account: 'account',
+      };
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.MetaMask,
+        publicKey: 'key',
+      });
+      store.overrideSelector(AuthSelectors.isUserLoggedIn, false);
+      store.overrideSelector(AuthSelectors.isMetamaskDisabled, false);
+      loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe((resultAction) => {
+        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        done();
+      });
+    });
+
+    it('should not call login method when session is empty', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(false);
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled()
+      done();
+    });
+
+    it('should not call login method when it is not using metamask', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.WalletConnect,
+        publicKey: 'key',
+      });
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
+      done();
+    });
+
+    it('should not call login method when it is using metamask but with wrong chain id (metamask is disabled)', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.MetaMask,
+        publicKey: 'key',
+      });
+
+      store.overrideSelector(AuthSelectors.isMetamaskDisabled, true);
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
+      done();
+    });
+
+    it('should not call login method when user is already logged in', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.MetaMask,
+        publicKey: 'key',
+      });
+
+      store.overrideSelector(AuthSelectors.isMetamaskDisabled, false);
+      store.overrideSelector(AuthSelectors.isUserLoggedIn, true);
+
+      effects.reinitializeLoggedUserWithMetamask$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
+      done();
+    })
+  });
+
   describe('reinitializeLoggedUser$', () => {
     beforeEach(() => {
       actions$ = new ReplaySubject(1);
@@ -364,7 +468,7 @@ describe('AuthEffects', () => {
       store.overrideSelector(AuthSelectors.isUserLoggedIn, false);
       loginServiceSpy.login.and.returnValue(of(false));
       loginServiceSpy.getSession.and.returnValue({
-        providerType: 'type',
+        providerType: ProviderType.WalletConnect,
         publicKey: 'key',
       });
 
@@ -383,7 +487,7 @@ describe('AuthEffects', () => {
       };
       loginServiceSpy.isSessionActive.and.returnValue(true);
       loginServiceSpy.getSession.and.returnValue({
-        providerType: 'type',
+        providerType: ProviderType.WalletConnect,
         publicKey: 'key',
       });
       store.overrideSelector(AuthSelectors.isUserLoggedIn, false);
@@ -394,6 +498,48 @@ describe('AuthEffects', () => {
         done();
       });
     });
+
+    it('should not call login method when session is empty', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(false);
+
+      effects.reinitializeLoggedUser$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled()
+      done();
+    });
+
+    it('should not call login when it is metamask', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.MetaMask,
+        publicKey: 'key',
+      });
+
+      effects.reinitializeLoggedUser$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
+      done();
+    });
+
+    it('should not call login method when user is already logged in', (done) => {
+      actions$.next(AuthActions.reinitializeAuth());
+
+      loginServiceSpy.isSessionActive.and.returnValue(true);
+
+      loginServiceSpy.getSession.and.returnValue({
+        providerType: ProviderType.WalletConnect,
+        publicKey: 'key',
+      });
+
+      store.overrideSelector(AuthSelectors.isUserLoggedIn, true);
+
+      effects.reinitializeLoggedUser$.subscribe();
+      expect(loginServiceSpy.login).not.toHaveBeenCalled();
+      done();
+    })
   });
 
   describe('setWalletProviderAfterLogin$', () => {

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -307,7 +307,7 @@ describe('AuthEffects', () => {
       });
 
       effects.reinitializeUser$.subscribe((resultAction) => {
-        expect(resultAction).toEqual(AuthActions.reinitializeAuth());
+        expect(resultAction).toEqual(AuthActions.reinitializeAuthWithoutMetamask());
         done();
       });
     });
@@ -393,7 +393,7 @@ describe('AuthEffects', () => {
     });
 
     it('should return failure action when reinitialization fails', (done) => {
-      actions$.next(AuthActions.reinitializeAuth());
+      actions$.next(AuthActions.reinitializeAuthWithoutMetamask());
       loginServiceSpy.reinitialize.and.returnValue(of(false));
       loginServiceSpy.getSession.and.returnValue({
         providerType: ProviderType.WalletConnect,
@@ -407,7 +407,7 @@ describe('AuthEffects', () => {
     });
 
     it('should return success action when reinitialization completes successfully', (done) => {
-      actions$.next(AuthActions.reinitializeAuth());
+      actions$.next(AuthActions.reinitializeAuthWithoutMetamask());
       loginServiceSpy.getSession.and.returnValue({
         providerType: ProviderType.WalletConnect,
         publicKey: 'key',
@@ -450,7 +450,7 @@ describe('AuthEffects', () => {
 
     it('should navigate to welcome page when session is not active', (done) => {
       loginServiceSpy.isSessionActive.and.returnValue(false);
-      actions$.next(AuthActions.reinitializeAuth());
+      actions$.next(AuthActions.reinitializeAuthWithoutMetamask());
       effects.notPossibleToReinitializeUser$.subscribe(() => {
         expect(routerSpy.navigate).toHaveBeenCalledWith([RouterConst.Welcome]);
         done();

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -307,7 +307,9 @@ describe('AuthEffects', () => {
       });
 
       effects.reinitializeUser$.subscribe((resultAction) => {
-        expect(resultAction).toEqual(AuthActions.reinitializeAuthWithoutMetamask());
+        expect(resultAction).toEqual(
+          AuthActions.reinitializeAuthWithoutMetamask()
+        );
         done();
       });
     });

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -145,15 +145,10 @@ describe('AuthEffects', () => {
     });
 
     it('should close dialog and return login success action when login was successful', (done) => {
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
       actions$.next(
         AuthActions.loginViaDialog({ provider: ProviderType.MetaMask })
       );
-      loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
+      loginServiceSpy.login.and.returnValue(of({ success: true }));
 
       effects.loginViaDialog$.subscribe((resultAction) => {
         expect(loginServiceSpy.login).toHaveBeenCalledWith(
@@ -163,7 +158,7 @@ describe('AuthEffects', () => {
           },
           undefined
         );
-        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        expect(resultAction).toEqual(AuthActions.loginSuccess());
         expect(dialogSpy.closeAll).toHaveBeenCalled();
 
         done();
@@ -229,24 +224,19 @@ describe('AuthEffects', () => {
     });
 
     it('should successfully login', (done) => {
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
       actions$.next(
         AuthActions.welcomeLogin({
           provider: ProviderType.MetaMask,
           returnUrl: '',
         })
       );
-      loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
+      loginServiceSpy.login.and.returnValue(of({ success: true }));
 
       effects.welcomePageLogin$
         .pipe(
           finalize(() => {
             expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(
-              '/dashboard',
+              '/' + RouterConst.Dashboard,
               jasmine.objectContaining({})
             );
           })
@@ -256,9 +246,7 @@ describe('AuthEffects', () => {
             providerType: ProviderType.MetaMask,
             reinitializeMetamask: true,
           });
-          expect(resultAction).toEqual(
-            AuthActions.loginSuccess({ accountInfo })
-          );
+          expect(resultAction).toEqual(AuthActions.loginSuccess());
           done();
         });
     });
@@ -270,12 +258,7 @@ describe('AuthEffects', () => {
           returnUrl: 'returnUrl',
         })
       );
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
-      loginServiceSpy.login.and.returnValue(of({ success: true, accountInfo }));
+      loginServiceSpy.login.and.returnValue(of({ success: true }));
 
       effects.welcomePageLogin$.subscribe((resultAction) => {
         expect(loginServiceSpy.login).toHaveBeenCalledWith({
@@ -285,7 +268,7 @@ describe('AuthEffects', () => {
         expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(
           `/${RouterConst.ReturnUrl}`
         );
-        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        expect(resultAction).toEqual(AuthActions.loginSuccess());
         done();
       });
     });
@@ -373,22 +356,15 @@ describe('AuthEffects', () => {
 
     it('should return success action when reinitialization completes successfully', (done) => {
       actions$.next(AuthActions.reinitializeAuthWithMetamask());
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
       loginServiceSpy.getSession.and.returnValue({
         providerType: ProviderType.MetaMask,
         publicKey: 'key',
       });
       store.overrideSelector(AuthSelectors.isMetamaskDisabled, false);
-      loginServiceSpy.reinitialize.and.returnValue(
-        of({ success: true, accountInfo })
-      );
+      loginServiceSpy.reinitialize.and.returnValue(of({ success: true }));
 
       effects.reinitializeLoggedUserWithMetamask$.subscribe((resultAction) => {
-        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        expect(resultAction).toEqual(AuthActions.loginSuccess());
         done();
       });
     });
@@ -432,21 +408,14 @@ describe('AuthEffects', () => {
 
     it('should return success action when reinitialization completes successfully', (done) => {
       actions$.next(AuthActions.reinitializeAuth());
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
       loginServiceSpy.getSession.and.returnValue({
         providerType: ProviderType.WalletConnect,
         publicKey: 'key',
       });
-      loginServiceSpy.reinitialize.and.returnValue(
-        of({ success: true, accountInfo })
-      );
+      loginServiceSpy.reinitialize.and.returnValue(of({ success: true }));
 
       effects.reinitializeLoggedUser$.subscribe((resultAction) => {
-        expect(resultAction).toEqual(AuthActions.loginSuccess({ accountInfo }));
+        expect(resultAction).toEqual(AuthActions.loginSuccess());
         done();
       });
     });
@@ -458,12 +427,7 @@ describe('AuthEffects', () => {
     });
 
     it('should return dispatch action for setting wallet provider', (done) => {
-      const accountInfo = {
-        chainName: 'chainName',
-        chainId: 123,
-        account: 'account',
-      };
-      actions$.next(AuthActions.loginSuccess({ accountInfo }));
+      actions$.next(AuthActions.loginSuccess());
       loginServiceSpy.getProviderType.and.returnValue(
         ProviderType.WalletConnect
       );

--- a/src/app/state/auth/auth.effects.ts
+++ b/src/app/state/auth/auth.effects.ts
@@ -78,10 +78,10 @@ export class AuthEffects {
             navigateOnTimeout
           )
           .pipe(
-            map(({ success, accountInfo }) => {
+            map(({ success }) => {
               if (success) {
                 this.dialog.closeAll();
-                return AuthActions.loginSuccess({ accountInfo });
+                return AuthActions.loginSuccess();
               }
               return AuthActions.loginFailure();
             }),
@@ -124,10 +124,10 @@ export class AuthEffects {
             reinitializeMetamask: provider === ProviderType.MetaMask,
           })
           .pipe(
-            map(({ success, accountInfo }) => {
+            map(({ success }) => {
               if (success) {
                 this.router.navigateByUrl(`/${returnUrl}`);
-                return AuthActions.loginSuccess({ accountInfo });
+                return AuthActions.loginSuccess();
               }
               return AuthActions.loginFailure();
             }),
@@ -280,9 +280,9 @@ export class AuthEffects {
         providerType: this.loginService.getSession().providerType,
       })
       .pipe(
-        map(({ success, accountInfo }) => {
+        map(({ success }) => {
           if (success) {
-            return AuthActions.loginSuccess({ accountInfo });
+            return AuthActions.loginSuccess();
           }
           return AuthActions.loginFailure();
         }),

--- a/src/app/state/auth/auth.effects.ts
+++ b/src/app/state/auth/auth.effects.ts
@@ -181,7 +181,7 @@ export class AuthEffects {
           return AuthActions.reinitializeAuthWithMetamask();
         }
 
-        return AuthActions.reinitializeAuth();
+        return AuthActions.reinitializeAuthWithoutMetamask();
       })
     )
   );
@@ -196,7 +196,7 @@ export class AuthEffects {
 
   reinitializeLoggedUser$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(AuthActions.reinitializeAuth),
+      ofType(AuthActions.reinitializeAuthWithoutMetamask),
       switchMap(() => this.reinitialize())
     )
   );
@@ -204,7 +204,7 @@ export class AuthEffects {
   notPossibleToReinitializeUser$ = createEffect(
     () =>
       this.actions$.pipe(
-        ofType(AuthActions.reinitializeAuth),
+        ofType(AuthActions.reinitializeAuthWithoutMetamask),
         filter(() => !this.loginService.isSessionActive()),
         map(() => {
           this.router.navigate([RouterConst.Welcome]);

--- a/src/app/state/auth/auth.reducer.ts
+++ b/src/app/state/auth/auth.reducer.ts
@@ -5,7 +5,6 @@ import { AccountInfo, ProviderType } from 'iam-client-lib';
 export const USER_FEATURE_KEY = 'auth';
 
 export interface AuthState {
-  accountInfo: AccountInfo;
   metamask: {
     present: boolean;
     chainId: number | undefined;
@@ -15,7 +14,6 @@ export interface AuthState {
 }
 
 export const initialState: AuthState = {
-  accountInfo: undefined,
   metamask: {
     present: true,
     chainId: undefined,
@@ -26,15 +24,13 @@ export const initialState: AuthState = {
 
 const authReducer = createReducer(
   initialState,
-  on(AuthActions.loginSuccess, (state, { accountInfo }) => ({
+  on(AuthActions.loginSuccess, (state) => ({
     ...state,
     loggedIn: true,
-    accountInfo,
   })),
   on(AuthActions.logout, AuthActions.logoutWithRedirectUrl, (state) => ({
     ...state,
     loggedIn: false,
-    accountInfo: undefined,
   })),
   on(AuthActions.setMetamaskLoginOptions, (state, { present, chainId }) => ({
     ...state,

--- a/src/app/state/auth/auth.reducer.ts
+++ b/src/app/state/auth/auth.reducer.ts
@@ -5,7 +5,6 @@ import { AccountInfo, ProviderType } from 'iam-client-lib';
 export const USER_FEATURE_KEY = 'auth';
 
 export interface AuthState {
-  walletProvider: ProviderType | undefined;
   accountInfo: AccountInfo;
   metamask: {
     present: boolean;
@@ -16,7 +15,6 @@ export interface AuthState {
 }
 
 export const initialState: AuthState = {
-  walletProvider: undefined,
   accountInfo: undefined,
   metamask: {
     present: true,
@@ -36,7 +34,6 @@ const authReducer = createReducer(
   on(AuthActions.logout, AuthActions.logoutWithRedirectUrl, (state) => ({
     ...state,
     loggedIn: false,
-    walletProvider: undefined,
     accountInfo: undefined,
   })),
   on(AuthActions.setMetamaskLoginOptions, (state, { present, chainId }) => ({

--- a/src/app/state/auth/auth.selectors.spec.ts
+++ b/src/app/state/auth/auth.selectors.spec.ts
@@ -63,20 +63,4 @@ describe('Auth Selectors', () => {
       ).toBeTruthy();
     });
   });
-
-  describe('getWalletProvider', () => {
-    it('should return undefined when wallet is not defined', () => {
-      expect(
-        authSelectors.getWalletProvider.projector({ walletProvider: undefined })
-      ).toBeUndefined();
-    });
-
-    it('should return defined wallet provider', () => {
-      expect(
-        authSelectors.getWalletProvider.projector({
-          walletProvider: ProviderType.WalletConnect,
-        })
-      ).toBe(ProviderType.WalletConnect);
-    });
-  });
 });

--- a/src/app/state/auth/auth.selectors.ts
+++ b/src/app/state/auth/auth.selectors.ts
@@ -17,8 +17,3 @@ export const isMetamaskDisabled = createSelector(
   getAuthState,
   (state) => state?.metamask.chainId !== state?.defaultChainId
 );
-
-export const getAccountInfo = createSelector(
-  getAuthState,
-  (state) => state.accountInfo
-);

--- a/src/app/state/auth/auth.selectors.ts
+++ b/src/app/state/auth/auth.selectors.ts
@@ -18,11 +18,6 @@ export const isMetamaskDisabled = createSelector(
   (state) => state?.metamask.chainId !== state?.defaultChainId
 );
 
-export const getWalletProvider = createSelector(
-  getAuthState,
-  (state) => state.walletProvider
-);
-
 export const getAccountInfo = createSelector(
   getAuthState,
   (state) => state.accountInfo

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -10,7 +10,6 @@ export const environment = {
   chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
-  kmsServerUrl: undefined,
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',
   showAzureLoginOption: true,
   natsEnvironmentName: 'ewf-dev',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,7 +10,6 @@ export const environment = {
   chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache.energyweb.org/v1',
   natsServerUrl: 'https://identityevents.energyweb.org/',
-  kmsServerUrl: 'https://kms.energyweb.org/connect/new',
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',
   showAzureLoginOption: false,
   natsEnvironmentName: 'ewf-prod',

--- a/src/environments/environment.stedin.ts
+++ b/src/environments/environment.stedin.ts
@@ -10,7 +10,6 @@ export const environment = {
   chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
-  kmsServerUrl: undefined,
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',
   showAzureLoginOption: true,
   natsEnvironmentName: 'ewf-dev',

--- a/src/environments/environment.stg.ts
+++ b/src/environments/environment.stg.ts
@@ -10,7 +10,6 @@ export const environment = {
   chainId: ChainId.Volta,
   cacheServerUrl: 'https://identitycache-staging.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-staging.energyweb.org/',
-  kmsServerUrl: 'https://kms.energyweb.org/connect/new',
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',
   showAzureLoginOption: true,
   natsEnvironmentName: 'ewf-dev',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,7 +15,6 @@ export const environment = {
   cacheServerUrl: 'https://identitycache-dev.energyweb.org/v1',
   natsServerUrl: 'https://identityevents-dev.energyweb.org/',
   ekcUrl: 'https://azure-proxy-server.energyweb.org/api/v1',
-  kmsServerUrl: undefined,
   showAzureLoginOption: true,
   natsEnvironmentName: 'ewf-dev',
   rootNamespace: 'iam.ewc',


### PR DESCRIPTION
It fixes two issues:
https://energyweb.atlassian.net/browse/SWTCH-1399
https://energyweb.atlassian.net/browse/SWTCH-1397

The issue for 1399 was a race condition between getting Metamask details and reinitialization (reinitialization was first always). Now it tries to reinitialize user after getting metamask information. I've split reinitialization on two separate actions: one with metamask, second without.
Adds timer for reinitialization (1397) - 1 minute to reinitialize like while logging in. If user do nothing, it will display popup.