### PR TITLE
Revert "Hotfix/set revocation address"

### DIFF
--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -262,8 +262,6 @@ export class IamService {
   private getChainConfig(): Partial<ChainConfig> {
     const chainConfig: Partial<ChainConfig> = {
       rpcUrl: this.envService.rpcUrl,
-      claimsRevocationRegistryAddress:
-        '0xd72B4c8D5B1a1A4C7085259548bDF1A175CFc48D',
     };
 
     return chainConfig;


### PR DESCRIPTION
Reverts energywebfoundation/switchboard-dapp#743

PR for reverting hotfix with revocation address. When ICL with configured revocation address will be ready to merge, this PR should be merged first.