### PR TITLE
fix: do not show enrolments for assets under 'My Enrolments'

### DIFF
--- a/src/app/state/enrolments/owned/owned.effects.ts
+++ b/src/app/state/enrolments/owned/owned.effects.ts
@@ -16,6 +16,11 @@ export class OwnedEnrolmentsEffects {
       tap(() => this.loadingService.show()),
       switchMap(() =>
         this.claimsFacade.getClaimsByRequester().pipe(
+          map((claims) => {
+            return claims.filter((claim) => {
+              return claim?.requester === claim?.subject;
+            });
+          }),
           this.getEnrolments(
             OwnedActions.getOwnedEnrolmentsSuccess,
             OwnedActions.getOwnedEnrolmentsFailure


### PR DESCRIPTION
- When creating the list of enrolments under 'My Enrolments', filter out enrolment requests that you are NOT the subject of. Otherwise enrolments for your assets will show up under 'My Enrolments'. 