### PR TITLE
fix (publish assets): pass subject DID to check for sync status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "bootstrap": "4.3.1",
         "core-js": "3.21.0",
         "hammerjs": "^2.0.8",
-        "iam-client-lib": "6.0.1",
+        "iam-client-lib": "6.2.0",
         "moment": "2.22.2",
         "ng-qrcode": "6.0.0",
         "ngx-bootstrap": "8.0.0",
@@ -3038,21 +3038,20 @@
       }
     },
     "node_modules/@energyweb/credential-governance": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.1.0.tgz",
-      "integrity": "sha512-+Lcju9mhzjcFKR1B6RXvUqsUSvbQvRvIkw+X9eAE91joVyHkYeiwJAAEy1XpZXeYN6e7q4vJlJWK1FeokOqlnA==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-ABOyQkZ3FOyhdiNLnaXhjop3POonYbrODWeQDIrgtWDfelc2eCp1eTY37QFOakPlwhqD4kp4th6GvNR5eUKppA==",
       "dependencies": {
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did": "^0.7.1-alpha.795.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@energyweb/credential-governance/node_modules/@ew-did-registry/credentials-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-      "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
       "dependencies": {
-        "@ethersproject/abstract-signer": "5.6.0",
         "@sphereon/pex": "^1.1.0",
         "@types/lodash": "^4.14.181",
         "joi": "^17.6.0",
@@ -3060,17 +3059,17 @@
       }
     },
     "node_modules/@energyweb/credential-governance/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@energyweb/ekc": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@energyweb/ekc/-/ekc-0.6.6.tgz",
-      "integrity": "sha512-RYrhzChLE3Y+SxUivxFuy8+/Sy/ZumTmpaCqiBb/T1XKf6diErXHhFKPKg3j0rcM/pCJtyW69Mn02ygunTSaqQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@energyweb/ekc/-/ekc-0.6.7.tgz",
+      "integrity": "sha512-ho3OeaqoE5ZlO7rtNDt5aPdBDo3W3sDe2+XGtADJuCKhGFVUP3w5ALiEeeVJgSrE0OUeIAg8xikrMApuC7Rz8A==",
       "dependencies": {
         "@azure/msal-browser": "~2.17.0",
-        "ethers": "~5.6.1"
+        "ethers": "~5.7.0"
       }
     },
     "node_modules/@energyweb/eslint-config": {
@@ -3086,21 +3085,21 @@
       }
     },
     "node_modules/@energyweb/onchain-claims": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.1.0.tgz",
-      "integrity": "sha512-Otbi2C8W6qbaMaL8Dtrsi/5HbtnFfbQ3eP0k6O3OOrlYNcqisb0lwxiiTd4/Q36ceusedKGMgwXTqZWC4mzXBg==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-XjNCbtBA9Iu1XFkQCJn6+61Y3opJT7mNITSgLzDXMNoA8tPstg08z/i2BLZgTsXlgYgurO9S58auHeEOUM0PkQ==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.1.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.293.0",
+        "@ew-did-registry/did": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
         "@poanet/solidity-flattener": "^3.0.7",
-        "ethers": "^5.6.1"
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@energyweb/onchain-claims/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@energyweb/prettier-config": {
       "version": "0.0.0",
@@ -3121,28 +3120,28 @@
       }
     },
     "node_modules/@energyweb/vc-verification": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.1.0.tgz",
-      "integrity": "sha512-HzU7P8D5aT62bbt5OVM63Lh2X87g/d4DDv7qpfRnMhYhi2ZgGUupzl4KZm5B965mkTaBQldro8q+Y+ZsTIyukA==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-0ZmeFmrdncLTysX4w7VDQK7dnK/ctqWUK6rHiLJR/Qzw7sFtH52TX3O4o7hm9zFSSb41ETRVsdMhBi7+Yvfgdw==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.1.0",
-        "@energyweb/onchain-claims": "2.1.0",
-        "@ew-did-registry/claims": "^0.7.0",
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
-        "@ew-did-registry/did-ipfs-store": "^0.7.0",
-        "@ew-did-registry/did-store-interface": "^0.7.0",
-        "@ew-did-registry/revocation": "^0.7.0",
-        "ethers": "^5.6.1",
-        "ipfs-http-client": "^43.0.0"
+        "@energyweb/credential-governance": "2.2.1-alpha.293.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.293.0",
+        "@ew-did-registry/claims": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ipfs-store": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-store-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/revocation": "^0.7.1-alpha.795.0",
+        "ethers": "^5.7.0",
+        "ipfs-http-client": "^43.0.0",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/credentials-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-      "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
       "dependencies": {
-        "@ethersproject/abstract-signer": "5.6.0",
         "@sphereon/pex": "^1.1.0",
         "@types/lodash": "^4.14.181",
         "joi": "^17.6.0",
@@ -3240,9 +3239,9 @@
       }
     },
     "node_modules/@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "funding": [
         {
           "type": "individual",
@@ -3254,21 +3253,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "funding": [
         {
           "type": "individual",
@@ -3280,13 +3279,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
@@ -3312,9 +3311,9 @@
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "funding": [
         {
           "type": "individual",
@@ -3326,17 +3325,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "funding": [
         {
           "type": "individual",
@@ -3348,13 +3347,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "funding": [
         {
           "type": "individual",
@@ -3366,14 +3365,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -3385,15 +3384,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -3405,13 +3404,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "funding": [
         {
           "type": "individual",
@@ -3423,13 +3422,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "funding": [
         {
           "type": "individual",
@@ -3441,22 +3440,22 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/contracts/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3468,17 +3467,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -3490,20 +3489,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3515,17 +3515,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "funding": [
         {
           "type": "individual",
@@ -3537,24 +3537,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hdnode/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3566,17 +3566,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "funding": [
         {
           "type": "individual",
@@ -3588,25 +3588,25 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/json-wallets/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3618,17 +3618,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "funding": [
         {
           "type": "individual",
@@ -3640,14 +3640,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "funding": [
         {
           "type": "individual",
@@ -3660,9 +3660,9 @@
       ]
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.0.tgz",
+      "integrity": "sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==",
       "funding": [
         {
           "type": "individual",
@@ -3674,13 +3674,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "funding": [
         {
           "type": "individual",
@@ -3692,14 +3692,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "funding": [
         {
           "type": "individual",
@@ -3711,13 +3711,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
+      "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
       "funding": [
         {
           "type": "individual",
@@ -3729,32 +3729,32 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "node_modules/@ethersproject/providers/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3766,17 +3766,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "funding": [
         {
           "type": "individual",
@@ -3788,14 +3788,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "funding": [
         {
           "type": "individual",
@@ -3807,14 +3807,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "funding": [
         {
           "type": "individual",
@@ -3826,15 +3826,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "funding": [
         {
           "type": "individual",
@@ -3846,18 +3846,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "funding": [
         {
           "type": "individual",
@@ -3869,18 +3869,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "funding": [
         {
           "type": "individual",
@@ -3892,15 +3892,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -3912,21 +3912,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "funding": [
         {
           "type": "individual",
@@ -3938,15 +3938,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "funding": [
         {
           "type": "individual",
@@ -3958,27 +3958,27 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3990,17 +3990,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.0.tgz",
+      "integrity": "sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==",
       "funding": [
         {
           "type": "individual",
@@ -4012,17 +4012,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "funding": [
         {
           "type": "individual",
@@ -4034,40 +4034,39 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/claims": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.7.0.tgz",
-      "integrity": "sha512-1K8zgvmn92m6A8n8juO0evTyauXk8NHa7k2xXZ4AsOID+fJNfe1XTtsf+5QLtvmv5c5jcJet0caa95kz/119VQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-fi5FRCWwDauuHw7v+ZykV7yfUoTbJPdGetR1YM7dB+45HzHS8z06womQ8v0lucmG8uJllaHFrTFVv6O4gqoXqg==",
       "dependencies": {
-        "@ew-did-registry/credentials-interface": "0.7.0",
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-document": "0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-ipfs-store": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/did-store-interface": "0.7.0",
-        "@ew-did-registry/jwt": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-document": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-store-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/jwt": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "@types/sjcl": "1.0.28",
         "base64url": "^3.0.1",
         "eciesjs": "^0.3.4",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "sjcl": "npm:sjcl-complete@1.0.0"
       }
     },
     "node_modules/@ew-did-registry/claims/node_modules/@ew-did-registry/credentials-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-      "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
       "dependencies": {
-        "@ethersproject/abstract-signer": "5.6.0",
         "@sphereon/pex": "^1.1.0",
         "@types/lodash": "^4.14.181",
         "joi": "^17.6.0",
@@ -4075,30 +4074,30 @@
       }
     },
     "node_modules/@ew-did-registry/claims/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@ew-did-registry/claims/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/claims/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -4125,42 +4124,42 @@
       "integrity": "sha512-lFwpOph7KEUqmVf6HHhV9x5TtixoncO/bXdqh+4hjq9h8yUolkdWITsFIjsj7z4z0WRLaI41WAJQq7sR/NcR0g=="
     },
     "node_modules/@ew-did-registry/did-document": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.7.0.tgz",
-      "integrity": "sha512-tk9QAiSTbFkvNVdgQe1CRYv18JZNFiQbjSbUhVApRQg/qMgw08hH/FJ8E+Q6ofPHS2qn1EnS+vsZVgJFePovDw==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9J2KF+KL4V/09M34Fc8mcdABGOnOmcF+YI1/loS6iGa8wHKacTryfSCWskHO4mYZRP3Li/G4Lalnt6hXHdGB2w==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/did-document/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@ew-did-registry/did-document/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/did-document/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -4170,41 +4169,41 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@ew-did-registry/did-ethr-resolver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.7.0.tgz",
-      "integrity": "sha512-EJyRXi47AsL+Ifbgd3PF0TIsBu8z5iBNd+c2qTAx3vz8qM9yoknS+earWjScI5JK0mwzwQZ4MbpsFJp9PgnlFg==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-e8MBxv1zGYbgmNpVU0ffLjjZqkK/V8dD3EgecVnAMHJiHq/9q6QV9ygKyybSqwu3PnvX+tFgPJcep5XCb0/3lg==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -4214,11 +4213,11 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@ew-did-registry/did-ipfs-store": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.7.0.tgz",
-      "integrity": "sha512-8zOC6FdKA4hsyo1VaeSsi3opC47RDsppFl9d5/DnQllG5nLs5r3k8PWicndszY18MAnm5ICnv+WMU5LsHrT3DQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-oVEhENMimHn1XkkBpGF1gaC+eWw5I87yyBtgmptixPFn5sZskDT9j+HkjnbTgbRQCSSj25mOceNU30avrjB+Sw==",
       "dependencies": {
-        "@ew-did-registry/did-store-interface": "0.7.0",
+        "@ew-did-registry/did-store-interface": "0.7.1-alpha.816.0",
         "bl": "^4.0.2",
         "ipfs-http-client": "^43.0.0"
       }
@@ -4234,34 +4233,34 @@
       }
     },
     "node_modules/@ew-did-registry/did-store-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.7.0.tgz",
-      "integrity": "sha512-0yhMvi/nRat88tZlokgcWiOshHTm//0IRpY4jdZNnOwn46FW20itKp6xTPmjHll+arAxUtDU1m+K07hjM9Ubag=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-w+D8ytESxdCjrNGJuHmgVq88By26ZR56Cs+N+ZwckB24rfq1Vvuu97mO8rxzj6VZcrKZN8IcPxzCeBbGjA1Fmg=="
     },
     "node_modules/@ew-did-registry/jwt": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.7.0.tgz",
-      "integrity": "sha512-vtYSh1sPD5iClAqea49CdYC5zfxgZ01DhkWDgH7Owv3jGiKEWbBAjJB0e1ylUf7UnOBhWSD69Qc2WmC1kos1fw==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-tAaDhPflj6x5DLQ3qjZ+l1WBeasZ+zJ6ukhFgmMeP6tBCbyxnjlyfaqzsj7asje9nBqXqxh7fzxTbxBp+GVg4Q==",
       "dependencies": {
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "base64url": "^3.0.1",
         "ec-key": "0.0.4",
         "ethereumjs-util": "^7.0.5",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "jsonwebtoken": "^8.5.1",
         "promise.allsettled": "^1.0.2"
       }
     },
     "node_modules/@ew-did-registry/jwt/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -4289,41 +4288,41 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@ew-did-registry/proxyidentity": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.7.0.tgz",
-      "integrity": "sha512-HDtvg3frY/YUmQF3az8CmodYozVbpkWi/8zhVYrY290tBGlm4r3lo5TMNGJUB/ah9Lw79zs3WCpw4BNwAC52fQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-/28j9fFKnXVnHT1V/MMfslsNBsGemzk+2oNwfT9Ps9xInM6BaYPIM/9U9f6Q6zwHrU/UyvTeFeEEn5p9PruJJQ==",
       "dependencies": {
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/proxyidentity/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@ew-did-registry/proxyidentity/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/proxyidentity/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -4333,26 +4332,25 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@ew-did-registry/revocation": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.7.0.tgz",
-      "integrity": "sha512-eVMOR/880bsbOzr93SqcRShk1x+wF9km9nKgTozZm08HqlIVUvJhXJzgn7Y8AOH1cWRo6fb03mKb8tngTvOKew==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-FxiA7vzXaS2juafUi4chYQLFrFsTNurZj9IvQuGoz61JTzOdZtCRC9FcPey/dRvHvvlPgwuqZSyn9qCFClxLBw==",
       "dependencies": {
-        "@ew-did-registry/credentials-interface": "0.7.0",
-        "@ew-did-registry/did": "0.7.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
         "@ew-did-registry/did-ethr-resolver": "0.6.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "axios": "^0.27.2",
         "didkit-wasm-node": "^0.1.6",
-        "ethers": "^5.6.1"
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/credentials-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-      "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
       "dependencies": {
-        "@ethersproject/abstract-signer": "5.6.0",
         "@sphereon/pex": "^1.1.0",
         "@types/lodash": "^4.14.181",
         "joi": "^17.6.0",
@@ -4360,9 +4358,9 @@
       }
     },
     "node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-ethr-resolver": {
       "version": "0.6.0",
@@ -4401,25 +4399,25 @@
       }
     },
     "node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -5701,9 +5699,9 @@
       }
     },
     "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
       "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -5765,9 +5763,9 @@
       "dev": true
     },
     "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -10812,9 +10810,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
+      "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
       "funding": [
         {
           "type": "individual",
@@ -10826,42 +10824,42 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.0",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.0",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.0",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/ethers/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -10873,11 +10871,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -12078,27 +12076,27 @@
       }
     },
     "node_modules/iam-client-lib": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-6.0.1.tgz",
-      "integrity": "sha512-xpJBRrTS/hBySTD+7sZSkoQ9v9dGqzaSyIif6v0Csc35C76jeT2TC0wqVRGiDlaN0zwnjyubv94i8ahs7uAMGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-6.2.0.tgz",
+      "integrity": "sha512-4UghD4DId6KVGOLvYhRHo6VYKJWBFuPSoQ6A/+An2jJaeaqQigabEHzmjbpjEfEDAHqUlQTYQDgCJbJI5FnfoA==",
       "dependencies": {
-        "@energyweb/credential-governance": "^2.0.1-alpha.275.0",
-        "@energyweb/ekc": "^0.6.6",
-        "@energyweb/onchain-claims": "^2.0.1-alpha.275.0",
+        "@energyweb/credential-governance": "^2.2.1-alpha.293.0",
+        "@energyweb/ekc": "^0.6.7",
+        "@energyweb/onchain-claims": "^2.2.1-alpha.293.0",
         "@energyweb/staking-pool": "^1.0.0-rc.14",
-        "@energyweb/vc-verification": "^2.0.1-alpha.275.0",
+        "@energyweb/vc-verification": "^2.2.1-alpha.293.0",
         "@ensdomains/ens": "^0.6.2",
-        "@ew-did-registry/claims": "^0.7.0",
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "@ew-did-registry/did-document": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
-        "@ew-did-registry/did-ipfs-store": "^0.7.0",
-        "@ew-did-registry/did-resolver-interface": "^0.7.0",
-        "@ew-did-registry/jwt": "^0.7.0",
-        "@ew-did-registry/keys": "^0.7.0",
-        "@ew-did-registry/proxyidentity": "^0.7.0",
-        "@ew-did-registry/revocation": "^0.7.0",
+        "@ew-did-registry/claims": "0.7.1-alpha.816.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-document": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/jwt": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "@ew-did-registry/proxyidentity": "0.7.1-alpha.816.0",
+        "@ew-did-registry/revocation": "0.7.1-alpha.816.0",
         "@gnosis.pm/safe-apps-provider": "^0.11.0",
         "@gnosis.pm/safe-apps-sdk": "^7.3.0",
         "@metamask/detect-provider": "^1.2.0",
@@ -12113,7 +12111,7 @@
         "didkit-wasm": "^0.1.9",
         "didkit-wasm-node": "^0.1.6",
         "eth-ens-namehash": "^2.0.8",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "js-sha3": "^0.8.0",
         "jsonwebtoken": "^8.5.1",
         "lodash.difference": "^4.5.0",
@@ -12134,11 +12132,10 @@
       }
     },
     "node_modules/iam-client-lib/node_modules/@ew-did-registry/credentials-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-      "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
       "dependencies": {
-        "@ethersproject/abstract-signer": "5.6.0",
         "@sphereon/pex": "^1.1.0",
         "@types/lodash": "^4.14.181",
         "joi": "^17.6.0",
@@ -12146,30 +12143,30 @@
       }
     },
     "node_modules/iam-client-lib/node_modules/@ew-did-registry/did": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-      "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
     },
     "node_modules/iam-client-lib/node_modules/@ew-did-registry/did-resolver-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-      "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
       "dependencies": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       }
     },
     "node_modules/iam-client-lib/node_modules/@ew-did-registry/keys": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-      "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
       "dependencies": {
         "bn.js": "5.2.0",
         "ec-key": "0.0.4",
         "eciesjs": "^0.3.4",
         "elliptic": "^6.5.2",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "key-encoder": "^2.0.3"
       }
     },
@@ -23264,21 +23261,20 @@
       "dev": true
     },
     "@energyweb/credential-governance": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.1.0.tgz",
-      "integrity": "sha512-+Lcju9mhzjcFKR1B6RXvUqsUSvbQvRvIkw+X9eAE91joVyHkYeiwJAAEy1XpZXeYN6e7q4vJlJWK1FeokOqlnA==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-ABOyQkZ3FOyhdiNLnaXhjop3POonYbrODWeQDIrgtWDfelc2eCp1eTY37QFOakPlwhqD4kp4th6GvNR5eUKppA==",
       "requires": {
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did": "^0.7.1-alpha.795.0",
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/credentials-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-          "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
           "requires": {
-            "@ethersproject/abstract-signer": "5.6.0",
             "@sphereon/pex": "^1.1.0",
             "@types/lodash": "^4.14.181",
             "joi": "^17.6.0",
@@ -23286,19 +23282,19 @@
           }
         },
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         }
       }
     },
     "@energyweb/ekc": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@energyweb/ekc/-/ekc-0.6.6.tgz",
-      "integrity": "sha512-RYrhzChLE3Y+SxUivxFuy8+/Sy/ZumTmpaCqiBb/T1XKf6diErXHhFKPKg3j0rcM/pCJtyW69Mn02ygunTSaqQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@energyweb/ekc/-/ekc-0.6.7.tgz",
+      "integrity": "sha512-ho3OeaqoE5ZlO7rtNDt5aPdBDo3W3sDe2+XGtADJuCKhGFVUP3w5ALiEeeVJgSrE0OUeIAg8xikrMApuC7Rz8A==",
       "requires": {
         "@azure/msal-browser": "~2.17.0",
-        "ethers": "~5.6.1"
+        "ethers": "~5.7.0"
       }
     },
     "@energyweb/eslint-config": {
@@ -23309,21 +23305,21 @@
       "requires": {}
     },
     "@energyweb/onchain-claims": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.1.0.tgz",
-      "integrity": "sha512-Otbi2C8W6qbaMaL8Dtrsi/5HbtnFfbQ3eP0k6O3OOrlYNcqisb0lwxiiTd4/Q36ceusedKGMgwXTqZWC4mzXBg==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-XjNCbtBA9Iu1XFkQCJn6+61Y3opJT7mNITSgLzDXMNoA8tPstg08z/i2BLZgTsXlgYgurO9S58auHeEOUM0PkQ==",
       "requires": {
-        "@energyweb/credential-governance": "2.1.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.293.0",
+        "@ew-did-registry/did": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
         "@poanet/solidity-flattener": "^3.0.7",
-        "ethers": "^5.6.1"
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         }
       }
     },
@@ -23344,28 +23340,28 @@
       }
     },
     "@energyweb/vc-verification": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.1.0.tgz",
-      "integrity": "sha512-HzU7P8D5aT62bbt5OVM63Lh2X87g/d4DDv7qpfRnMhYhi2ZgGUupzl4KZm5B965mkTaBQldro8q+Y+ZsTIyukA==",
+      "version": "2.2.1-alpha.293.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.293.0.tgz",
+      "integrity": "sha512-0ZmeFmrdncLTysX4w7VDQK7dnK/ctqWUK6rHiLJR/Qzw7sFtH52TX3O4o7hm9zFSSb41ETRVsdMhBi7+Yvfgdw==",
       "requires": {
-        "@energyweb/credential-governance": "2.1.0",
-        "@energyweb/onchain-claims": "2.1.0",
-        "@ew-did-registry/claims": "^0.7.0",
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
-        "@ew-did-registry/did-ipfs-store": "^0.7.0",
-        "@ew-did-registry/did-store-interface": "^0.7.0",
-        "@ew-did-registry/revocation": "^0.7.0",
-        "ethers": "^5.6.1",
-        "ipfs-http-client": "^43.0.0"
+        "@energyweb/credential-governance": "2.2.1-alpha.293.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.293.0",
+        "@ew-did-registry/claims": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-ipfs-store": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/did-store-interface": "^0.7.1-alpha.795.0",
+        "@ew-did-registry/revocation": "^0.7.1-alpha.795.0",
+        "ethers": "^5.7.0",
+        "ipfs-http-client": "^43.0.0",
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "@ew-did-registry/credentials-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-          "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
           "requires": {
-            "@ethersproject/abstract-signer": "5.6.0",
             "@sphereon/pex": "^1.1.0",
             "@types/lodash": "^4.14.181",
             "joi": "^17.6.0",
@@ -23444,33 +23440,33 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "@ethersproject/abstract-signer": {
@@ -23486,444 +23482,444 @@
       }
     },
     "@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "requires": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
     },
     "@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.0.tgz",
+      "integrity": "sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
+      "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
     },
     "@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.0.tgz",
+      "integrity": "sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==",
       "requires": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ew-did-registry/claims": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.7.0.tgz",
-      "integrity": "sha512-1K8zgvmn92m6A8n8juO0evTyauXk8NHa7k2xXZ4AsOID+fJNfe1XTtsf+5QLtvmv5c5jcJet0caa95kz/119VQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-fi5FRCWwDauuHw7v+ZykV7yfUoTbJPdGetR1YM7dB+45HzHS8z06womQ8v0lucmG8uJllaHFrTFVv6O4gqoXqg==",
       "requires": {
-        "@ew-did-registry/credentials-interface": "0.7.0",
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-document": "0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-ipfs-store": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/did-store-interface": "0.7.0",
-        "@ew-did-registry/jwt": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-document": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-store-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/jwt": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "@types/sjcl": "1.0.28",
         "base64url": "^3.0.1",
         "eciesjs": "^0.3.4",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "sjcl": "npm:sjcl-complete@1.0.0"
       },
       "dependencies": {
         "@ew-did-registry/credentials-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-          "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
           "requires": {
-            "@ethersproject/abstract-signer": "5.6.0",
             "@sphereon/pex": "^1.1.0",
             "@types/lodash": "^4.14.181",
             "joi": "^17.6.0",
@@ -23931,30 +23927,30 @@
           }
         },
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -23983,42 +23979,42 @@
       "integrity": "sha512-lFwpOph7KEUqmVf6HHhV9x5TtixoncO/bXdqh+4hjq9h8yUolkdWITsFIjsj7z4z0WRLaI41WAJQq7sR/NcR0g=="
     },
     "@ew-did-registry/did-document": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.7.0.tgz",
-      "integrity": "sha512-tk9QAiSTbFkvNVdgQe1CRYv18JZNFiQbjSbUhVApRQg/qMgw08hH/FJ8E+Q6ofPHS2qn1EnS+vsZVgJFePovDw==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-9J2KF+KL4V/09M34Fc8mcdABGOnOmcF+YI1/loS6iGa8wHKacTryfSCWskHO4mYZRP3Li/G4Lalnt6hXHdGB2w==",
       "requires": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -24030,41 +24026,41 @@
       }
     },
     "@ew-did-registry/did-ethr-resolver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.7.0.tgz",
-      "integrity": "sha512-EJyRXi47AsL+Ifbgd3PF0TIsBu8z5iBNd+c2qTAx3vz8qM9yoknS+earWjScI5JK0mwzwQZ4MbpsFJp9PgnlFg==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-e8MBxv1zGYbgmNpVU0ffLjjZqkK/V8dD3EgecVnAMHJiHq/9q6QV9ygKyybSqwu3PnvX+tFgPJcep5XCb0/3lg==",
       "requires": {
-        "@ew-did-registry/did": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -24076,11 +24072,11 @@
       }
     },
     "@ew-did-registry/did-ipfs-store": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.7.0.tgz",
-      "integrity": "sha512-8zOC6FdKA4hsyo1VaeSsi3opC47RDsppFl9d5/DnQllG5nLs5r3k8PWicndszY18MAnm5ICnv+WMU5LsHrT3DQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-oVEhENMimHn1XkkBpGF1gaC+eWw5I87yyBtgmptixPFn5sZskDT9j+HkjnbTgbRQCSSj25mOceNU30avrjB+Sw==",
       "requires": {
-        "@ew-did-registry/did-store-interface": "0.7.0",
+        "@ew-did-registry/did-store-interface": "0.7.1-alpha.816.0",
         "bl": "^4.0.2",
         "ipfs-http-client": "^43.0.0"
       }
@@ -24096,34 +24092,34 @@
       }
     },
     "@ew-did-registry/did-store-interface": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.7.0.tgz",
-      "integrity": "sha512-0yhMvi/nRat88tZlokgcWiOshHTm//0IRpY4jdZNnOwn46FW20itKp6xTPmjHll+arAxUtDU1m+K07hjM9Ubag=="
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-w+D8ytESxdCjrNGJuHmgVq88By26ZR56Cs+N+ZwckB24rfq1Vvuu97mO8rxzj6VZcrKZN8IcPxzCeBbGjA1Fmg=="
     },
     "@ew-did-registry/jwt": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.7.0.tgz",
-      "integrity": "sha512-vtYSh1sPD5iClAqea49CdYC5zfxgZ01DhkWDgH7Owv3jGiKEWbBAjJB0e1ylUf7UnOBhWSD69Qc2WmC1kos1fw==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-tAaDhPflj6x5DLQ3qjZ+l1WBeasZ+zJ6ukhFgmMeP6tBCbyxnjlyfaqzsj7asje9nBqXqxh7fzxTbxBp+GVg4Q==",
       "requires": {
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "base64url": "^3.0.1",
         "ec-key": "0.0.4",
         "ethereumjs-util": "^7.0.5",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "jsonwebtoken": "^8.5.1",
         "promise.allsettled": "^1.0.2"
       },
       "dependencies": {
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -24155,41 +24151,41 @@
       }
     },
     "@ew-did-registry/proxyidentity": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.7.0.tgz",
-      "integrity": "sha512-HDtvg3frY/YUmQF3az8CmodYozVbpkWi/8zhVYrY290tBGlm4r3lo5TMNGJUB/ah9Lw79zs3WCpw4BNwAC52fQ==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-/28j9fFKnXVnHT1V/MMfslsNBsGemzk+2oNwfT9Ps9xInM6BaYPIM/9U9f6Q6zwHrU/UyvTeFeEEn5p9PruJJQ==",
       "requires": {
-        "@ew-did-registry/did-ethr-resolver": "0.7.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
-        "ethers": "^5.6.1"
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -24201,26 +24197,25 @@
       }
     },
     "@ew-did-registry/revocation": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.7.0.tgz",
-      "integrity": "sha512-eVMOR/880bsbOzr93SqcRShk1x+wF9km9nKgTozZm08HqlIVUvJhXJzgn7Y8AOH1cWRo6fb03mKb8tngTvOKew==",
+      "version": "0.7.1-alpha.816.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.7.1-alpha.816.0.tgz",
+      "integrity": "sha512-FxiA7vzXaS2juafUi4chYQLFrFsTNurZj9IvQuGoz61JTzOdZtCRC9FcPey/dRvHvvlPgwuqZSyn9qCFClxLBw==",
       "requires": {
-        "@ew-did-registry/credentials-interface": "0.7.0",
-        "@ew-did-registry/did": "0.7.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
         "@ew-did-registry/did-ethr-resolver": "0.6.0",
-        "@ew-did-registry/did-resolver-interface": "0.7.0",
-        "@ew-did-registry/keys": "0.7.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
         "axios": "^0.27.2",
         "didkit-wasm-node": "^0.1.6",
-        "ethers": "^5.6.1"
+        "ethers": "^5.7.0"
       },
       "dependencies": {
         "@ew-did-registry/credentials-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-          "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
           "requires": {
-            "@ethersproject/abstract-signer": "5.6.0",
             "@sphereon/pex": "^1.1.0",
             "@types/lodash": "^4.14.181",
             "joi": "^17.6.0",
@@ -24228,9 +24223,9 @@
           }
         },
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-ethr-resolver": {
           "version": "0.6.0",
@@ -24271,25 +24266,25 @@
           }
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },
@@ -25355,9 +25350,9 @@
       }
     },
     "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -25419,9 +25414,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "@types/node": {
       "version": "12.20.55",
@@ -29214,52 +29209,52 @@
       }
     },
     "ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
+      "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
       "requires": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.0",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.0",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.0",
+        "@ethersproject/wordlists": "5.7.0"
       },
       "dependencies": {
         "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
           }
         }
       }
@@ -30189,27 +30184,27 @@
       }
     },
     "iam-client-lib": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-6.0.1.tgz",
-      "integrity": "sha512-xpJBRrTS/hBySTD+7sZSkoQ9v9dGqzaSyIif6v0Csc35C76jeT2TC0wqVRGiDlaN0zwnjyubv94i8ahs7uAMGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-6.2.0.tgz",
+      "integrity": "sha512-4UghD4DId6KVGOLvYhRHo6VYKJWBFuPSoQ6A/+An2jJaeaqQigabEHzmjbpjEfEDAHqUlQTYQDgCJbJI5FnfoA==",
       "requires": {
-        "@energyweb/credential-governance": "^2.0.1-alpha.275.0",
-        "@energyweb/ekc": "^0.6.6",
-        "@energyweb/onchain-claims": "^2.0.1-alpha.275.0",
+        "@energyweb/credential-governance": "^2.2.1-alpha.293.0",
+        "@energyweb/ekc": "^0.6.7",
+        "@energyweb/onchain-claims": "^2.2.1-alpha.293.0",
         "@energyweb/staking-pool": "^1.0.0-rc.14",
-        "@energyweb/vc-verification": "^2.0.1-alpha.275.0",
+        "@energyweb/vc-verification": "^2.2.1-alpha.293.0",
         "@ensdomains/ens": "^0.6.2",
-        "@ew-did-registry/claims": "^0.7.0",
-        "@ew-did-registry/credentials-interface": "^0.7.0",
-        "@ew-did-registry/did": "^0.7.0",
-        "@ew-did-registry/did-document": "^0.7.0",
-        "@ew-did-registry/did-ethr-resolver": "^0.7.0",
-        "@ew-did-registry/did-ipfs-store": "^0.7.0",
-        "@ew-did-registry/did-resolver-interface": "^0.7.0",
-        "@ew-did-registry/jwt": "^0.7.0",
-        "@ew-did-registry/keys": "^0.7.0",
-        "@ew-did-registry/proxyidentity": "^0.7.0",
-        "@ew-did-registry/revocation": "^0.7.0",
+        "@ew-did-registry/claims": "0.7.1-alpha.816.0",
+        "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-document": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
+        "@ew-did-registry/did-resolver-interface": "0.7.1-alpha.816.0",
+        "@ew-did-registry/jwt": "0.7.1-alpha.816.0",
+        "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+        "@ew-did-registry/proxyidentity": "0.7.1-alpha.816.0",
+        "@ew-did-registry/revocation": "0.7.1-alpha.816.0",
         "@gnosis.pm/safe-apps-provider": "^0.11.0",
         "@gnosis.pm/safe-apps-sdk": "^7.3.0",
         "@metamask/detect-provider": "^1.2.0",
@@ -30224,7 +30219,7 @@
         "didkit-wasm": "^0.1.9",
         "didkit-wasm-node": "^0.1.6",
         "eth-ens-namehash": "^2.0.8",
-        "ethers": "^5.6.1",
+        "ethers": "^5.7.0",
         "fsevents": "^2.3.2",
         "js-sha3": "^0.8.0",
         "jsonwebtoken": "^8.5.1",
@@ -30239,11 +30234,10 @@
       },
       "dependencies": {
         "@ew-did-registry/credentials-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.0.tgz",
-          "integrity": "sha512-hYeqI1m/F4EXi2BZBclMB0ZTXGJTg/cJM/pTsBTbJ7ThAt22aVz2Zv7ArbuqkT6HGP8v0uzBU+FMcqdMUiRP7Q==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-VPGpg8/5HRTlCIUdIF0l8AkvnqgdP5f+8pb0GkzJUYFMmHAP3Jz+lAYgOEehTbTOWn+9ssJfNRlZ+Ko8B3P/2w==",
           "requires": {
-            "@ethersproject/abstract-signer": "5.6.0",
             "@sphereon/pex": "^1.1.0",
             "@types/lodash": "^4.14.181",
             "joi": "^17.6.0",
@@ -30251,30 +30245,30 @@
           }
         },
         "@ew-did-registry/did": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.0.tgz",
-          "integrity": "sha512-X3w2PmPoDYBN1W3eNHkwdp1NLVmxNZbXh9zf6UdXTyUOm7+DUYp/pZ4d08zQ7taVVjSqx2mhH7CJWzCnmKiUbQ=="
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-9/yxxK1+PLCMNS0V84VtUKCaKLO5xCjg64pkQXhW+g4Auye2J+o3ABEdLXAvKNXlrHN1IgFXX0d1xoRgTj0BAg=="
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.0.tgz",
-          "integrity": "sha512-e9jw9YF8LAZu+R93NICj5fOiHnOkIfACGNvdQ6xWDROcyxgQRxJoWwUIK4zJ4bPPmPMGKKgq8PmskzvkjlDnag==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-IuywSBk1BclAcuSBS3Kb9sSuhFZTVjE7W6kzbUS7n5DEqbAEbN44iJ2qWo/suBHn2EWDGt051JtncCFHnFUn4A==",
           "requires": {
-            "@ew-did-registry/did": "0.7.0",
-            "@ew-did-registry/keys": "0.7.0",
-            "ethers": "^5.6.1"
+            "@ew-did-registry/did": "0.7.1-alpha.816.0",
+            "@ew-did-registry/keys": "0.7.1-alpha.816.0",
+            "ethers": "^5.7.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.0.tgz",
-          "integrity": "sha512-9OnY8CPK6NIVoahHSqXR5NaE6A3Ap6w1pTvIpQ1xS1zF98jVw3Sm+o+VbUbr4+sVnS+JQCsIWkhFmrJayeSQng==",
+          "version": "0.7.1-alpha.816.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.7.1-alpha.816.0.tgz",
+          "integrity": "sha512-h7yCo5CKQGSKTbaRpYGLFuvzCOclDVluxmX8USAJlPrLUT/mT8IZsIxrpyzjHYZoiXAAfI86vD8Ewk32j+r2tw==",
           "requires": {
             "bn.js": "5.2.0",
             "ec-key": "0.0.4",
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2",
-            "ethers": "^5.6.1",
+            "ethers": "^5.7.0",
             "key-encoder": "^2.0.3"
           }
         },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bootstrap": "4.3.1",
     "core-js": "3.21.0",
     "hammerjs": "^2.0.8",
-    "iam-client-lib": "6.0.1",
+    "iam-client-lib": "6.2.0",
     "moment": "2.22.2",
     "ng-qrcode": "6.0.0",
     "ngx-bootstrap": "8.0.0",

--- a/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
+++ b/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
@@ -89,6 +89,7 @@ export class AssetEnrolmentListComponent implements OnInit {
         registrationTypes: element.registrationTypes,
         claimType: element.claimType,
         claimTypeVersion: element.claimTypeVersion,
+        subject: element.subject,
       })
       .pipe(truthy())
       .subscribe(() => this.getList());

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnDestroy,
   OnInit,
   Output,
   ViewChild,
@@ -162,6 +161,12 @@ export class MyEnrolmentListComponent implements OnInit {
         type: ColumnType.DID,
         field: 'requester',
         header: 'Requestor DID',
+      },
+      {
+        type: ColumnType.DID,
+        field: 'subject',
+        header: 'Asset DID',
+        condition: (element: EnrolmentClaim) => element.isAsset(),
       },
       {
         type: ColumnType.Custom,

--- a/src/app/shared/services/claims-facade/claims-facade.service.spec.ts
+++ b/src/app/shared/services/claims-facade/claims-facade.service.spec.ts
@@ -50,56 +50,24 @@ describe('ClaimsFacadeService', () => {
         claimType: createClaimType(claimType),
       } as Claim);
     };
-
-    it('should return empty list when getting empty list', async () => {
-      claimsServiceSpy.getUserClaims.and.returnValue(Promise.resolve([]));
-      expect(await service.addStatusIfIsSyncedOffChain([])).toEqual([]);
-    });
-
-    it('should return not changed list when UserClaims is empty', async () => {
-      claimsServiceSpy.getUserClaims.and.returnValue(Promise.resolve([]));
-      expect(
-        await service.addStatusIfIsSyncedOffChain([createClaim('123')])
-      ).toEqual([
-        jasmine.objectContaining({
-          claimType: createClaimType('123'),
-          isSyncedOffChain: false,
-        }),
-      ]);
-    });
-
-    it('should return list with object containing isSynced property', async () => {
+    it('should return true for isSyncedOffChain if the claim type matches the subject claims', async () => {
       const claimType = createClaimType('123');
       claimsServiceSpy.getUserClaims.and.returnValue(
         Promise.resolve([{ claimType }])
       );
       expect(
-        await service.addStatusIfIsSyncedOffChain([
-          createClaim('123'),
-          createClaim('111'),
-        ])
-      ).toEqual([
-        jasmine.objectContaining({ claimType, isSyncedOffChain: true }),
-        jasmine.objectContaining({
-          claimType: createClaimType('111'),
-          isSyncedOffChain: false,
-        }),
-      ]);
+        await service.addStatusIfIsSyncedOffChain(createClaim('123'))
+      ).toEqual(jasmine.objectContaining({ isSyncedOffChain: true }));
     });
 
-    it('should not change list when claimType do not match', async () => {
+    it('should return false for isSyncedOffChain if the claim type does not match the subject claims', async () => {
+      const claimType = createClaimType('12');
       claimsServiceSpy.getUserClaims.and.returnValue(
-        Promise.resolve([{ claimType: createClaimType('12') }])
+        Promise.resolve([{ claimType }])
       );
-
       expect(
-        await service.addStatusIfIsSyncedOffChain([createClaim('123')])
-      ).toEqual([
-        jasmine.objectContaining({
-          claimType: createClaimType('123'),
-          isSyncedOffChain: false,
-        }),
-      ]);
+        await service.addStatusIfIsSyncedOffChain(createClaim('123'))
+      ).toEqual(jasmine.objectContaining({ isSyncedOffChain: false }));
     });
   });
 

--- a/src/app/shared/services/claims-facade/claims-facade.service.ts
+++ b/src/app/shared/services/claims-facade/claims-facade.service.ts
@@ -85,13 +85,9 @@ export class ClaimsFacadeService {
   }
 
   async addStatusIfIsSyncedOnChain(enrolment: EnrolmentClaim) {
-    const subjectDid =
-      enrolment?.subject === this.iamService.signerService.did
-        ? this.iamService.signerService.did
-        : enrolment.subject;
     if (enrolment.isRegisteredOnChain()) {
       const hasOnChainRole = await this.iamService.claimsService.hasOnChainRole(
-        subjectDid,
+        enrolment.subject,
         enrolment.claimType,
         +enrolment.claimTypeVersion
       );

--- a/src/app/shared/services/claims-facade/claims-facade.service.ts
+++ b/src/app/shared/services/claims-facade/claims-facade.service.ts
@@ -57,12 +57,12 @@ export class ClaimsFacadeService {
     );
   }
 
-  hasOnChainRole(role: string, version: number) {
-    return this.iamService.claimsService.hasOnChainRole(
-      this.iamService.signerService.did,
-      role,
-      version
-    );
+  hasOnChainRole(
+    role: string,
+    version: number,
+    subject = this.iamService.signerService.did
+  ) {
+    return this.iamService.claimsService.hasOnChainRole(subject, role, version);
   }
 
   getClaimsBySubject(did) {
@@ -84,13 +84,14 @@ export class ClaimsFacadeService {
     ).pipe(this.createEnrolmentClaimsFromClaims());
   }
 
-  async addStatusIfIsSyncedOnChain(
-    enrolment: EnrolmentClaim,
-    requesterIsDid = true
-  ) {
+  async addStatusIfIsSyncedOnChain(enrolment: EnrolmentClaim) {
+    const subjectDid =
+      enrolment?.subject === this.iamService.signerService.did
+        ? this.iamService.signerService.did
+        : enrolment.subject;
     if (enrolment.isRegisteredOnChain()) {
       const hasOnChainRole = await this.iamService.claimsService.hasOnChainRole(
-        requesterIsDid ? this.iamService.signerService.did : enrolment.subject,
+        subjectDid,
         enrolment.claimType,
         +enrolment.claimTypeVersion
       );
@@ -100,12 +101,11 @@ export class ClaimsFacadeService {
   }
 
   getClaimsByRevoker(): Observable<EnrolmentClaim[]> {
-    const requesterIsDid = false;
     return from(
       this.iamService.claimsService.getClaimsByRevoker({
         did: this.iamService.signerService.did,
       })
-    ).pipe(this.createEnrolmentClaimsFromClaims(requesterIsDid));
+    ).pipe(this.createEnrolmentClaimsFromClaims());
   }
 
   getClaimsByIssuer(): Observable<EnrolmentClaim[]> {
@@ -150,7 +150,7 @@ export class ClaimsFacadeService {
     return from(this.iamService.claimsService.registerOnchain(claim));
   }
 
-  private createEnrolmentClaimsFromClaims(requesterIsDid = true) {
+  private createEnrolmentClaimsFromClaims() {
     return (source: Observable<Claim[]>) =>
       source.pipe(
         map((claims) => claims.filter((claim) => isValidDID(claim.subject))),
@@ -158,12 +158,9 @@ export class ClaimsFacadeService {
           claims.map((claim: Claim) => new EnrolmentClaim(claim))
         ),
         switchMap((enrolments: EnrolmentClaim[]) =>
-          from(this.addStatusIfIsSyncedOffChain(enrolments))
-        ),
-        switchMap((enrolments: EnrolmentClaim[]) =>
           forkJoin([
             ...enrolments.map((enrolment) =>
-              from(this.addStatusIfIsSyncedOnChain(enrolment, requesterIsDid))
+              from(this.addStatusIfIsSyncedOnChain(enrolment))
             ),
           ])
         ),
@@ -183,17 +180,23 @@ export class ClaimsFacadeService {
               from(this.setDecodedToken(enrolment))
             ),
           ])
+        ),
+        switchMap((enrolments: EnrolmentClaim[]) =>
+          forkJoin([
+            ...enrolments.map((enrolment) =>
+              from(this.addStatusIfIsSyncedOffChain(enrolment))
+            ),
+          ])
         )
       );
   }
 
-  async addStatusIfIsSyncedOffChain(
-    list: EnrolmentClaim[],
-    did?: string
-  ): Promise<EnrolmentClaim[]> {
+  async addStatusIfIsSyncedOffChain(enrolment: EnrolmentClaim) {
     // Get Approved Claims in DID Doc & Idenitfy Only Role-related Claims
     const claims: ClaimData[] = (
-      await this.iamService.claimsService.getUserClaims({ did })
+      await this.iamService.claimsService.getUserClaims({
+        did: enrolment.subject,
+      })
     )
       .filter((item) => item && item.claimType)
       .filter((item: ClaimData) => {
@@ -201,11 +204,9 @@ export class ClaimsFacadeService {
         return arr.length > 1 && arr[1] === NamespaceType.Role;
       });
 
-    return list.map((item: EnrolmentClaim) => {
-      return item.setIsSyncedOffChain(
-        claims.some((claim) => claim.claimType === item.claimType)
-      );
-    });
+    return enrolment.setIsSyncedOffChain(
+      claims.some((claim) => claim.claimType === enrolment.claimType)
+    );
   }
 
   setIsRevokedOnChainStatus(

--- a/src/app/shared/services/publish-role/publish-role.service.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.ts
@@ -30,6 +30,7 @@ export class PublishRoleService {
     registrationTypes: RegistrationTypes[];
     claimType: string;
     claimTypeVersion: string;
+    subject?: string;
   }) {
     return this.openConfirmationDialog({
       header: 'Publish credential to my DID document',
@@ -54,7 +55,8 @@ export class PublishRoleService {
         ...item,
         notSyncedOnChain: !(await this.claimsFacade.hasOnChainRole(
           item.claimType,
-          parseInt(item.claimTypeVersion.toString(), 10)
+          parseInt(item.claimTypeVersion.toString(), 10),
+          item.subject
         )),
       };
     }
@@ -86,6 +88,7 @@ export class PublishRoleService {
     registrationTypes: RegistrationTypes[];
     claimType: string;
     claimTypeVersion: string;
+    subject?: string;
   }) {
     this.loadingService.show(
       'Please confirm this transaction in your connected wallet.',


### PR DESCRIPTION
Addresses bugs for Assets in 'My Enrolment Requests' view:
1. pass in subject DID (rather than signer DID) for sync checks (isSyncedOnChain, isSycnedOffChain) for your asset's enrolments. This fixes the issue of if you have an approved role for an asset, and you navigate to 'My Enrolment Requests' and you click "publish" for your asset's approved role, the publish is successful and the "publish" button disappears. (Previous behavior - when you click "publish", the button would never disappear as the sync checks for the enrolment were incorrect - they were using signer DID rather than asset did)
2. Add "Asset DID" column to "My Enrolments" view. This is to indicate that the enrolment is for your asset DID, not your DID. The table looks v. crowded with this in there. 
