### PR TITLE
chore: update asset manager address

### DIFF
--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -268,6 +268,7 @@ export class IamService {
   private getChainConfig(): Partial<ChainConfig> {
     const chainConfig: Partial<ChainConfig> = {
       rpcUrl: this.envService.rpcUrl,
+      assetManagerAddress: '0x524563FeA0c9b54B337F0bAc366A9f541d26b3ea',
     };
 
     return chainConfig;


### PR DESCRIPTION
This PR hotfixes `AssetManager` contract address as a temporary fix to unblock `Asset` functionality.