### PR TITLE
fix: revert asset manager hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bootstrap": "4.6.2",
     "core-js": "3.21.0",
     "hammerjs": "^2.0.8",
-    "iam-client-lib": "7.0.0-alpha.3",
+    "iam-client-lib": "7.0.0",
     "moment": "2.29.4",
     "ng-qrcode": "6.0.0",
     "ngx-bootstrap": "8.0.0",

--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -268,7 +268,6 @@ export class IamService {
   private getChainConfig(): Partial<ChainConfig> {
     const chainConfig: Partial<ChainConfig> = {
       rpcUrl: this.envService.rpcUrl,
-      assetManagerAddress: '0x524563FeA0c9b54B337F0bAc366A9f541d26b3ea',
     };
 
     return chainConfig;


### PR DESCRIPTION
This PR updates `iam-client-lib` to `v7.0.0` and reverts the hot fix for AssetManager address.