### PR TITLE
Fix/reduce number of calls

### DIFF
--- a/src/app/state/auth/auth.actions.ts
+++ b/src/app/state/auth/auth.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { AccountInfo, ProviderType } from 'iam-client-lib';
+import { ProviderType } from 'iam-client-lib';
 
 export const init = createAction(
   '[AUTH] Initialize Possible Options To Log In'

--- a/src/app/state/auth/auth.effects.spec.ts
+++ b/src/app/state/auth/auth.effects.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { of, ReplaySubject, throwError } from 'rxjs';
 

--- a/src/app/state/auth/auth.effects.ts
+++ b/src/app/state/auth/auth.effects.ts
@@ -14,7 +14,6 @@ import { ConnectToWalletDialogComponent } from '../../modules/connect-to-wallet/
 import * as AuthSelectors from './auth.selectors';
 import { EnvService } from '../../shared/services/env/env.service';
 import { RouterConst } from '../../routes/router-const';
-import { OwnedEnrolmentsActions, RequestedEnrolmentsActions } from '@state';
 
 @Injectable()
 export class AuthEffects {
@@ -143,11 +142,7 @@ export class AuthEffects {
   userSuccessfullyLoggedIn$ = createEffect(() =>
     this.actions$.pipe(
       ofType(AuthActions.loginSuccess),
-      mergeMap(() => [
-        userActions.setUpUser(),
-        OwnedEnrolmentsActions.getOwnedEnrolments(),
-        RequestedEnrolmentsActions.getEnrolmentRequests(),
-      ])
+      mergeMap(() => [userActions.setUpUser()])
     )
   );
 

--- a/src/app/state/auth/auth.reducer.ts
+++ b/src/app/state/auth/auth.reducer.ts
@@ -1,6 +1,5 @@
 import { Action, createReducer, on } from '@ngrx/store';
 import * as AuthActions from './auth.actions';
-import { AccountInfo, ProviderType } from 'iam-client-lib';
 
 export const USER_FEATURE_KEY = 'auth';
 

--- a/src/app/state/auth/auth.selectors.spec.ts
+++ b/src/app/state/auth/auth.selectors.spec.ts
@@ -1,5 +1,4 @@
 import * as authSelectors from './auth.selectors';
-import { ProviderType } from 'iam-client-lib';
 import { ChainId } from '../../core/config/chain-id';
 
 describe('Auth Selectors', () => {

--- a/src/app/state/enrolments/owned/owned.effects.spec.ts
+++ b/src/app/state/enrolments/owned/owned.effects.spec.ts
@@ -6,7 +6,6 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { OwnedEnrolmentsEffects } from './owned.effects';
 import * as OwnedActions from './owned.actions';
-import { EnrolmentClaim } from '../../../routes/enrolment/models/enrolment-claim';
 import { LoadingService } from '../../../shared/services/loading.service';
 import { ClaimsFacadeService } from '../../../shared/services/claims-facade/claims-facade.service';
 

--- a/src/app/state/user-claim/user.effects.spec.ts
+++ b/src/app/state/user-claim/user.effects.spec.ts
@@ -24,8 +24,6 @@ describe('UserEffects', () => {
         UserEffects,
         { provide: IamService, useValue: iamServiceSpy },
         { provide: LoadingService, useValue: loadingServiceSpy },
-        { provide: MatDialog, useValue: dialogSpy },
-        { provide: ToastrService, useValue: toastrSpy },
         provideMockStore(),
         provideMockActions(() => actions$),
       ],

--- a/src/app/state/user-claim/user.effects.spec.ts
+++ b/src/app/state/user-claim/user.effects.spec.ts
@@ -11,6 +11,8 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { ToastrService } from 'ngx-toastr';
 import { dialogSpy, iamServiceSpy, loadingServiceSpy, toastrSpy } from '@tests';
 import * as UserClaimActions from './user.actions';
+import { skip, take } from 'rxjs/operators';
+import { OwnedEnrolmentsActions, RequestedEnrolmentsActions } from '@state';
 
 describe('UserEffects', () => {
   let actions$: ReplaySubject<any>;
@@ -71,13 +73,32 @@ describe('UserEffects', () => {
       actions$ = new ReplaySubject(1);
     });
 
+    it('should call for owned and requested enrolments', (done) => {
+      actions$.next(UserClaimActions.loadUserClaimsSuccess({ userClaims: [] }));
+
+      effects.getUserProfile$
+        .pipe(skip(1), take(1))
+        .subscribe((resultAction) => {
+          expect(resultAction).toEqual(
+            RequestedEnrolmentsActions.getEnrolmentRequests()
+          );
+        });
+
+      effects.getUserProfile$.pipe(take(1)).subscribe((resultAction) => {
+        expect(resultAction).toEqual(
+          OwnedEnrolmentsActions.getOwnedEnrolments()
+        );
+      });
+      done();
+    });
+
     it('should return empty object as a profile when passing empty list', (done) => {
       const claims = [];
       actions$.next(
         UserClaimActions.loadUserClaimsSuccess({ userClaims: claims })
       );
 
-      effects.getUserProfile$.subscribe((resultAction) => {
+      effects.getUserProfile$.pipe(skip(2)).subscribe((resultAction) => {
         expect(resultAction).toEqual(
           UserClaimActions.setProfile({ profile: {} })
         );
@@ -95,7 +116,7 @@ describe('UserEffects', () => {
         UserClaimActions.loadUserClaimsSuccess({ userClaims: claims } as any)
       );
 
-      effects.getUserProfile$.subscribe((resultAction) => {
+      effects.getUserProfile$.pipe(skip(2)).subscribe((resultAction) => {
         expect(resultAction).toEqual(
           UserClaimActions.setProfile({ profile: {} })
         );
@@ -130,7 +151,7 @@ describe('UserEffects', () => {
         UserClaimActions.loadUserClaimsSuccess({ userClaims: claims } as any)
       );
 
-      effects.getUserProfile$.subscribe((resultAction) => {
+      effects.getUserProfile$.pipe(skip(2)).subscribe((resultAction) => {
         expect(resultAction).toEqual(UserClaimActions.setProfile({ profile }));
         done();
       });
@@ -178,7 +199,7 @@ describe('UserEffects', () => {
         UserClaimActions.loadUserClaimsSuccess({ userClaims: claims } as any)
       );
 
-      effects.getUserProfile$.subscribe((resultAction) => {
+      effects.getUserProfile$.pipe(skip(2)).subscribe((resultAction) => {
         expect(resultAction).toEqual(
           UserClaimActions.setProfile({ profile: firstClaim.profile } as any)
         );

--- a/src/app/state/user-claim/user.effects.ts
+++ b/src/app/state/user-claim/user.effects.ts
@@ -18,6 +18,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { UserClaimState } from './user.reducer';
 import { ToastrService } from 'ngx-toastr';
 import * as UserClaimActions from './user.actions';
+import { OwnedEnrolmentsActions, RequestedEnrolmentsActions } from '@state';
 
 @Injectable()
 export class UserEffects {
@@ -44,7 +45,11 @@ export class UserEffects {
       ofType(UserClaimActions.loadUserClaimsSuccess),
       map((userClaimsAction) => userClaimsAction.userClaims),
       mapClaimsProfile(),
-      map((profile: Profile) => UserClaimActions.setProfile({ profile }))
+      mergeMap((profile: Profile) => [
+        UserClaimActions.setProfile({ profile }),
+        OwnedEnrolmentsActions.getOwnedEnrolments(),
+        RequestedEnrolmentsActions.getEnrolmentRequests(),
+      ])
     )
   );
 

--- a/src/app/state/user-claim/user.effects.ts
+++ b/src/app/state/user-claim/user.effects.ts
@@ -46,9 +46,9 @@ export class UserEffects {
       map((userClaimsAction) => userClaimsAction.userClaims),
       mapClaimsProfile(),
       mergeMap((profile: Profile) => [
-        UserClaimActions.setProfile({ profile }),
         OwnedEnrolmentsActions.getOwnedEnrolments(),
         RequestedEnrolmentsActions.getEnrolmentRequests(),
+        UserClaimActions.setProfile({ profile }),
       ])
     )
   );

--- a/src/app/state/user-claim/user.effects.ts
+++ b/src/app/state/user-claim/user.effects.ts
@@ -69,26 +69,10 @@ export class UserEffects {
     )
   );
 
-  private mergeProfiles(
-    oldProfile: Partial<Profile>,
-    newProfile: Partial<Profile>
-  ): Partial<Profile> {
-    return {
-      ...oldProfile,
-      ...newProfile,
-      assetProfiles: {
-        ...oldProfile?.assetProfiles,
-        ...newProfile?.assetProfiles,
-      },
-    };
-  }
-
   constructor(
     private actions$: Actions,
     private store: Store<UserClaimState>,
     private iamService: IamService,
     private loadingService: LoadingService,
-    private toastr: ToastrService,
-    private dialog: MatDialog
   ) {}
 }

--- a/src/app/state/user-claim/user.effects.ts
+++ b/src/app/state/user-claim/user.effects.ts
@@ -73,6 +73,6 @@ export class UserEffects {
     private actions$: Actions,
     private store: Store<UserClaimState>,
     private iamService: IamService,
-    private loadingService: LoadingService,
+    private loadingService: LoadingService
   ) {}
 }

--- a/src/app/state/user-claim/user.reducer.ts
+++ b/src/app/state/user-claim/user.reducer.ts
@@ -1,7 +1,8 @@
 import { Action, createReducer, on } from '@ngrx/store';
-import { Profile } from 'iam-client-lib';
+import { ClaimData, Profile } from 'iam-client-lib';
 import * as userActions from './user.actions';
 import { userLocalStorage } from '../../shared/utils/local-storage-wrapper';
+import { IServiceEndpoint } from '@ew-did-registry/did-resolver-interface';
 
 export const USER_FEATURE_KEY = 'user';
 
@@ -15,6 +16,7 @@ export interface UserClaimState {
     birthdate: string;
     address: string;
   };
+  userClaims: (IServiceEndpoint & ClaimData)[];
 }
 
 export const initialState: UserClaimState = {
@@ -22,6 +24,7 @@ export const initialState: UserClaimState = {
   profile: null,
   error: '',
   userData: null,
+  userClaims: [],
 };
 
 const userReducer = createReducer(
@@ -34,6 +37,10 @@ const userReducer = createReducer(
       profile,
     })
   ),
+  on(userActions.loadUserClaimsSuccess, (state, { userClaims }) => ({
+    ...state,
+    userClaims,
+  })),
   on(userActions.updateUserData, (state, { userData }) => {
     userLocalStorage.parsed = {
       ...userLocalStorage.parsed,

--- a/src/app/state/user-claim/user.selectors.spec.ts
+++ b/src/app/state/user-claim/user.selectors.spec.ts
@@ -1,4 +1,5 @@
 import * as userSelectors from './user.selectors';
+import { claimRoleNames } from './user.selectors';
 import { AssetProfile } from 'iam-client-lib';
 
 describe('User Selectors', () => {
@@ -58,6 +59,30 @@ describe('User Selectors', () => {
       expect(
         userSelectors.getDid.projector({ didDocument: { id: 'test' } })
       ).toEqual('test');
+    });
+  });
+
+  describe('getUserRoleClaims', () => {
+    it('should filter out claims that are not roles', () => {
+      const claims = [{ claimType: 'will-be-filtered' }];
+      expect(userSelectors.getUserRoleClaims.projector(claims)).toEqual([]);
+    });
+
+    it('should pass further claim that is role', () => {
+      const claims = [{ claimType: 'valid.roles.org.iam.ewc' }];
+      expect(userSelectors.getUserRoleClaims.projector(claims)).toEqual(
+        claims as any
+      );
+    });
+  });
+
+  describe('claimRoleNames', () => {
+    it('should get list of role names', () => {
+      const roleName = 'some.roles.';
+      const claims = [{ claimType: roleName }];
+      expect(userSelectors.claimRoleNames.projector(claims)).toEqual([
+        roleName,
+      ]);
     });
   });
 });

--- a/src/app/state/user-claim/user.selectors.ts
+++ b/src/app/state/user-claim/user.selectors.ts
@@ -1,6 +1,6 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { USER_FEATURE_KEY, UserClaimState } from './user.reducer';
-import { Profile } from 'iam-client-lib';
+import { ClaimData, NamespaceType, Profile } from 'iam-client-lib';
 import { userLocalStorage } from '../../shared/utils/local-storage-wrapper';
 
 export const getUserState =
@@ -40,4 +40,21 @@ export const getDid = createSelector(
 export const getDIDDocument = createSelector(
   getUserState,
   (state: UserClaimState) => state?.didDocument
+);
+
+export const getUserClaims = createSelector(
+  getUserState,
+  (state) => state.userClaims
+);
+export const getUserRoleClaims = createSelector(getUserClaims, (claims) =>
+  claims
+    .filter((item) => item && item.claimType)
+    .filter((item: ClaimData) => {
+      const arr = item.claimType.split('.');
+      return arr.length > 1 && arr[1] === NamespaceType.Role;
+    })
+);
+
+export const claimRoleNames = createSelector(getUserRoleClaims, (claims) =>
+  claims.map((claim) => claim.claimType)
 );


### PR DESCRIPTION
Reduces number of calls while getting list of enrolments.
Previously it was getting list of user claims for every enrolment -> 100 enrolments = 100 additional requests.
Now it is using userClaims store slice where I'm storing user claims.