### PR TITLE
fix: close connection error, as signerService might not be initialised

### DIFF
--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -30,7 +30,7 @@ import * as Sentry from '@sentry/angular';
 import { Severity } from '@sentry/angular';
 import { LoadingService } from './loading.service';
 import { safeAppSdk } from './gnosis.safe.service';
-import { from, Observable } from 'rxjs';
+import { from, Observable, of } from 'rxjs';
 import { LoginOptions } from './login/login.service';
 import { truthy } from '@operators';
 import { finalize, map } from 'rxjs/operators';
@@ -157,6 +157,9 @@ export class IamService {
   }
 
   closeConnection() {
+    if (!this.signerService) {
+      return of(true);
+    }
     return from(this.signerService.closeConnection()).pipe(truthy());
   }
 

--- a/src/app/shared/services/login/login.service.ts
+++ b/src/app/shared/services/login/login.service.ts
@@ -159,11 +159,9 @@ export class LoginService {
 
   disconnect(): void {
     this.clearSession();
-    if (this.iamService) {
-      this.iamService.closeConnection().subscribe(() => {
-        location.reload();
-      });
-    }
+    this.iamService.closeConnection().subscribe(() => {
+      location.reload();
+    });
   }
 
   setDeepLink(deepLink: string) {


### PR DESCRIPTION
Previous fix was wrong, as we need to have signer service initialised. IamService is always available => method exist.