### PR TITLE
fix: error with getting allowed roles by issuer

### DIFF
--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -22,6 +22,7 @@ import { truthy } from '@operators';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { MessageSubscriptionService } from '../../shared/services/message-subscription/message-subscription.service';
 import { RouterConst } from '../../routes/router-const';
+import { IssuanceVcService } from '../../modules/issue-vc/services/issuance-vc.service';
 
 @Component({
   selector: 'app-header',
@@ -55,7 +56,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private store: Store,
     private loginService: LoginService,
     private didBookService: DidBookService,
-    private messageSubscriptionService: MessageSubscriptionService
+    private messageSubscriptionService: MessageSubscriptionService,
+    private issuanceVcService: IssuanceVcService
   ) {}
 
   async ngOnDestroy(): Promise<void> {
@@ -95,6 +97,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         this.didBookService.getList();
         await this.notifService.init();
         await this.messageSubscriptionService.init();
+        this.issuanceVcService.init();
         this.store.dispatch(LayoutActions.redirect());
       });
 

--- a/src/app/modules/issue-vc/services/issuance-vc.service.spec.ts
+++ b/src/app/modules/issue-vc/services/issuance-vc.service.spec.ts
@@ -39,6 +39,7 @@ describe('IssuanceVcService', () => {
       ])
     );
     service = TestBed.inject(IssuanceVcService);
+    service.init();
   });
 
   it('should be created', () => {

--- a/src/app/modules/issue-vc/services/issuance-vc.service.ts
+++ b/src/app/modules/issue-vc/services/issuance-vc.service.ts
@@ -2,9 +2,12 @@
 import { Injectable } from '@angular/core';
 import { IamService } from '../../../shared/services/iam.service';
 import { LoadingService } from '../../../shared/services/loading.service';
-import { finalize, map, tap } from 'rxjs/operators';
+import { finalize, map, switchMap, tap } from 'rxjs/operators';
 import { Claim, IRole, RegistrationTypes } from 'iam-client-lib';
 import { Observable } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { AuthSelectors } from '@state';
+import { truthy } from '@operators';
 
 @Injectable({
   providedIn: 'root',
@@ -16,7 +19,9 @@ export class IssuanceVcService {
   constructor(
     private iamService: IamService,
     private loadingService: LoadingService
-  ) {
+  ) {}
+
+  init() {
     this.getAllowedRoles();
   }
 


### PR DESCRIPTION
Should fix this error: https://energyweb.atlassian.net/browse/SWTCH-1756
It might call `getAllowedRolesByIssuer` method from domainsService, while domainsService wasn't yet initialised.