### PR TITLE
feat(iam.service): set domain to window origin

### DIFF
--- a/src/app/shared/services/iam.service.ts
+++ b/src/app/shared/services/iam.service.ts
@@ -66,6 +66,9 @@ export class IamService {
     // Set Cache Server
     setCacheConfig(envService.chainId, {
       url: envService.cacheServerUrl,
+      auth: {
+        domain: window.location.origin,
+      },
     });
 
     // Set RPC


### PR DESCRIPTION
Setting SIWE domain to have appropriate signature message.
Similar to https://github.com/energywebfoundation/gp4btc/pull/257