### PR TITLE
fix: json schema validation in enrolment form

### DIFF
--- a/src/app/routes/registration/enrolment-form/enrolment-form.component.html
+++ b/src/app/routes/registration/enrolment-form/enrolment-form.component.html
@@ -58,8 +58,8 @@
             class="mt-2 md-enroll"
             *ngIf="fieldList[i].fieldType === 'json'"
             [attr.data-qa-id]="'field-' + i"
-            [options]="createOptions(fieldList[i].schema)"
-            (change)="checkJson($event, fieldList[i].schema)"
+            [options]="createOptions(fieldList[i].schema, fieldList[i].label)"
+            (change)="checkJson($event, fieldList[i].schema, fieldList[i].label)"
             [formControl]="getControl(i)"
             [ngStyle]="txtColor">
             <mat-error *ngIf="getControl(i)?.errors?.required"> This field is required.</mat-error>


### PR DESCRIPTION
fix for: https://energyweb.atlassian.net/browse/SWTCH-2305
Tested with similar json schema.
Now it validates fields with empty object (it is set probably by json-editor) at setting up view.
Also it checks validation in every json schema field. 

https://www.loom.com/share/83179102aea349c4a9e3e30b78825510