### PR TITLE
fix: displaying publish button for claims

### DIFF
--- a/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.html
+++ b/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.html
@@ -5,8 +5,9 @@
   <button
     mat-menu-item
     class="btn-color-primary"
-    (click)="addToDidDoc(element)"
-    *ngIf="isPendingSync(element) && isAccepted(element)">
+    (updated)="this.getList()"
+    [appPublishRole]="element"
+    *ngIf="getEnrolmentClaim(element).canPublishClaim">
     <mat-icon class="btn-color-primary">note_add</mat-icon>
     <span>Publish</span>
   </button>
@@ -15,7 +16,7 @@
     mat-menu-item
     class="btn-color-error"
     (click)="cancelClaimRequest(element)"
-    *ngIf="!element?.isAccepted && !element?.isRejected">
+    *ngIf="getEnrolmentClaim(element).canCancelClaimRequest">
     <mat-icon class="btn-color-error">highlight_off</mat-icon>
     <span>Cancel Enrolment Request</span>
   </button>
@@ -24,7 +25,7 @@
   <app-enrolment-status [claim]="element">
     <div class="mt-2 mt-md-2 mb-md-2">
       <mat-icon class="color-warned icon-small mr-2" svgIcon="sync-did-icon"></mat-icon>
-      <span class="default-color cursor-pointer" (click)="addToDidDoc(element)">Publish</span>
+      <span class="default-color cursor-pointer" (updated)="this.getList()" [appPublishRole]="element">Publish</span>
     </div>
   </app-enrolment-status>
 </ng-template>

--- a/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
+++ b/src/app/routes/assets/asset-enrolment-list/asset-enrolment-list.component.ts
@@ -2,15 +2,12 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { IamService } from '../../../shared/services/iam.service';
 import { LoadingService } from '../../../shared/services/loading.service';
-import { NotificationService } from '../../../shared/services/notification.service';
 import { ConfirmationDialogComponent } from '../../widgets/confirmation-dialog/confirmation-dialog.component';
 import { MatSort } from '@angular/material/sort';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { SwitchboardToastrService } from '../../../shared/services/switchboard-toastr.service';
-import { truthy } from '@operators';
 import { Store } from '@ngrx/store';
 import { EnrolmentClaim } from '../../enrolment/models/enrolment-claim';
-import { PublishRoleService } from '../../../shared/services/publish-role/publish-role.service';
 import { ClaimsFacadeService } from '../../../shared/services/claims-facade/claims-facade.service';
 import {
   ColumnDefinition,
@@ -40,9 +37,7 @@ export class AssetEnrolmentListComponent implements OnInit {
     private iamService: IamService,
     private dialog: MatDialog,
     private toastr: SwitchboardToastrService,
-    private notifService: NotificationService,
     private store: Store,
-    private publishRoleService: PublishRoleService,
     private claimsFacade: ClaimsFacadeService
   ) {}
 
@@ -62,37 +57,8 @@ export class AssetEnrolmentListComponent implements OnInit {
     this.loadingService.hide();
   }
 
-  isAccepted(element: EnrolmentClaim) {
-    return element?.isAccepted;
-  }
-
-  isSynced(element: EnrolmentClaim) {
-    return element?.isSynced;
-  }
-
-  isRejected(element: EnrolmentClaim) {
-    return !element?.isAccepted && element?.isRejected;
-  }
-
-  isPending(element: EnrolmentClaim) {
-    return !element?.isAccepted && !element?.isRejected;
-  }
-
-  isPendingSync(element: EnrolmentClaim) {
-    return !element?.isSynced;
-  }
-
-  async addToDidDoc(element: EnrolmentClaim) {
-    this.publishRoleService
-      .addToDidDoc({
-        issuedToken: element.issuedToken,
-        registrationTypes: element.registrationTypes,
-        claimType: element.claimType,
-        claimTypeVersion: element.claimTypeVersion,
-        subject: element.subject,
-      })
-      .pipe(truthy())
-      .subscribe(() => this.getList());
+  getEnrolmentClaim(element: EnrolmentClaim) {
+    return element;
   }
 
   async cancelClaimRequest(element: EnrolmentClaim) {

--- a/src/app/routes/assets/assets.module.ts
+++ b/src/app/routes/assets/assets.module.ts
@@ -30,6 +30,7 @@ import { QrCodeScannerModule } from '../../shared/components/qr-code-scanner/qr-
 import { RouterConst } from '../router-const';
 import { AssetEnrolmentListComponent } from './asset-enrolment-list/asset-enrolment-list.component';
 import { EnrolmentListModule } from '../enrolment/enrolment-list/enrolment-list.module';
+import { PublishRoleDirective } from '../../shared/services/publish-role/publish-role.directive';
 
 const routes: Routes = [
   { path: '', component: AssetsComponent },
@@ -74,6 +75,7 @@ const routes: Routes = [
     ClipboardModule,
     QrCodeScannerModule,
     EnrolmentListModule,
+    PublishRoleDirective,
   ],
 })
 export class AssetsModule {}

--- a/src/app/routes/enrolment/enrolment.module.ts
+++ b/src/app/routes/enrolment/enrolment.module.ts
@@ -28,6 +28,7 @@ import { IssuerRequestsComponent } from './view-requests/issuer-requests/issuer-
 import { CascadingFilterModule } from '../../modules/cascading-filter/cascading-filter.module';
 import { RawDataModule } from 'src/app/modules/raw-data/raw-data.module';
 import { CredentialJsonComponent } from './view-requests/components/full-credential/full-credential.component';
+import { PublishRoleDirective } from '../../shared/services/publish-role/publish-role.directive';
 
 const routes: Routes = [{ path: '', component: EnrolmentComponent }];
 
@@ -65,6 +66,7 @@ const routes: Routes = [{ path: '', component: EnrolmentComponent }];
     EnrolmentListModule,
     CascadingFilterModule,
     RawDataModule,
+    PublishRoleDirective,
   ],
 })
 export class EnrolmentModule {}

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.html
@@ -6,8 +6,9 @@
   <button
     mat-menu-item
     class="btn-color-primary"
-    (click)="addToDidDoc(element)"
-    *ngIf="isPendingSync(element) && isAccepted(element)">
+    [appPublishRole]="element"
+    (updated)="updateList(element)"
+    *ngIf="getEnrolmentClaim(element).canPublishClaim">
     <mat-icon class="btn-color-primary">note_add</mat-icon>
     <span>Publish</span>
   </button>
@@ -25,7 +26,9 @@
   <app-enrolment-status [claim]="element">
     <div class="mt-2 mt-md-2 mb-md-2">
       <mat-icon class="color-warned icon-small mr-2" svgIcon="sync-did-icon"></mat-icon>
-      <span class="default-color cursor-pointer" (click)="addToDidDoc(element)">Publish</span>
+      <span class="default-color cursor-pointer" [appPublishRole]="element" (updated)="updateList(element)"
+        >Publish</span
+      >
     </div>
   </app-enrolment-status>
 </ng-template>

--- a/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
+++ b/src/app/routes/enrolment/my-enrolment-list/my-enrolment-list.component.ts
@@ -12,8 +12,6 @@ import { LoadingService } from '../../../shared/services/loading.service';
 import { IamService } from '../../../shared/services/iam.service';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { SwitchboardToastrService } from '../../../shared/services/switchboard-toastr.service';
-import { Store } from '@ngrx/store';
-import { PublishRoleService } from '../../../shared/services/publish-role/publish-role.service';
 import { ViewRequestsComponent } from '../view-requests/view-requests.component';
 import { truthy } from '@operators';
 import { ConfirmationDialogComponent } from '../../widgets/confirmation-dialog/confirmation-dialog.component';
@@ -56,21 +54,15 @@ export class MyEnrolmentListComponent implements OnInit {
     private loadingService: LoadingService,
     private iamService: IamService,
     private dialog: MatDialog,
-    private toastr: SwitchboardToastrService,
-    private store: Store,
-    private publishRoleService: PublishRoleService
+    private toastr: SwitchboardToastrService
   ) {}
 
   ngOnInit() {
     this.defineColumns();
   }
 
-  isAccepted(element: EnrolmentClaim) {
-    return element?.isAccepted;
-  }
-
-  isPendingSync(element: EnrolmentClaim) {
-    return !element?.isSynced;
+  getEnrolmentClaim(element: EnrolmentClaim) {
+    return element;
   }
 
   view(element: EnrolmentClaim) {
@@ -85,18 +77,6 @@ export class MyEnrolmentListComponent implements OnInit {
         disableClose: true,
       })
       .afterClosed()
-      .pipe(truthy())
-      .subscribe(() => this.updateList(element));
-  }
-
-  addToDidDoc(element: EnrolmentClaim) {
-    this.publishRoleService
-      .addToDidDoc({
-        issuedToken: element.issuedToken,
-        registrationTypes: element.registrationTypes,
-        claimType: element.claimType,
-        claimTypeVersion: element.claimTypeVersion,
-      })
       .pipe(truthy())
       .subscribe(() => this.updateList(element));
   }

--- a/src/app/shared/services/claims-facade/claims-facade.service.ts
+++ b/src/app/shared/services/claims-facade/claims-facade.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 import { IamService } from '../iam.service';
 import {
   Claim,
-  isValidDID,
-  RegistrationTypes,
   IssueClaimRequestOptions,
+  isValidDID,
+  PublishPublicClaimOptions,
   RejectClaimRequestOptions,
   RoleCredentialSubject,
 } from 'iam-client-lib';
@@ -146,13 +146,7 @@ export class ClaimsFacadeService {
   publishPublicClaim({
     registrationTypes,
     claim,
-  }: {
-    registrationTypes?: RegistrationTypes[];
-    claim: {
-      token: string;
-      claimType: string;
-    };
-  }): Observable<string | undefined> {
+  }: PublishPublicClaimOptions): Observable<string | undefined> {
     return from(
       this.iamService.claimsService.publishPublicClaim({
         registrationTypes,

--- a/src/app/shared/services/publish-role/publish-role.directive.spec.ts
+++ b/src/app/shared/services/publish-role/publish-role.directive.spec.ts
@@ -52,8 +52,6 @@ describe('PublishRoleDirective', () => {
     hostDebug = fixture.debugElement;
   }));
 
-  beforeEach(() => {});
-
   it('should create component with directive', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();

--- a/src/app/shared/services/publish-role/publish-role.directive.spec.ts
+++ b/src/app/shared/services/publish-role/publish-role.directive.spec.ts
@@ -1,0 +1,71 @@
+import { PublishRoleDirective } from './publish-role.directive';
+import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { PublishRoleService } from './publish-role.service';
+import { EnrolmentClaim } from '../../../routes/enrolment/models/enrolment-claim';
+import { of } from 'rxjs';
+import { getElement } from '@tests';
+import { Claim, RegistrationTypes } from 'iam-client-lib';
+
+@Component({
+  template: `
+    <div
+      data-qa-id="publish"
+      [appPublishRole]="enrolment"
+      (updated)="emitted = emitted + 1">
+      Publish
+    </div>
+  `,
+})
+class TestComponent {
+  emitted = 0;
+  enrolment = new EnrolmentClaim({
+    isAccepted: true,
+    registrationTypes: [RegistrationTypes.OffChain, RegistrationTypes.OnChain],
+    claimType: '',
+  } as Claim)
+    .setIsSyncedOnChain(false)
+    .setIsSyncedOffChain(false);
+}
+
+describe('PublishRoleDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let hostDebug: DebugElement;
+  let publishRoleServiceMock: jasmine.SpyObj<PublishRoleService>;
+  beforeEach(waitForAsync(() => {
+    publishRoleServiceMock = jasmine.createSpyObj('PublishRoleService', [
+      'addToDidDoc',
+    ]);
+
+    TestBed.configureTestingModule({
+      imports: [PublishRoleDirective],
+      declarations: [TestComponent],
+      providers: [
+        { provide: PublishRoleService, useValue: publishRoleServiceMock },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    hostDebug = fixture.debugElement;
+  }));
+
+  beforeEach(() => {});
+
+  it('should create component with directive', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit value when successfully publish claim', () => {
+    publishRoleServiceMock.addToDidDoc.and.returnValue(of(true));
+    fixture.detectChanges();
+    getElement(hostDebug)('publish').nativeElement.click();
+
+    expect(component.emitted).toEqual(1);
+    expect(component.enrolment.isSyncedOnChain).toBeTrue();
+    expect(component.enrolment.isSyncedOffChain).toBeTrue();
+  });
+});

--- a/src/app/shared/services/publish-role/publish-role.directive.ts
+++ b/src/app/shared/services/publish-role/publish-role.directive.ts
@@ -1,0 +1,28 @@
+import {
+  Directive,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+import { PublishRoleService } from './publish-role.service';
+import { EnrolmentClaim } from '../../../routes/enrolment/models/enrolment-claim';
+
+@Directive({
+  selector: '[appPublishRole]',
+  standalone: true,
+})
+export class PublishRoleDirective {
+  @Input() appPublishRole: EnrolmentClaim;
+  @Output() updated = new EventEmitter<void>();
+  constructor(private publishRoleService: PublishRoleService) {}
+
+  @HostListener('click') publishRole() {
+    this.publishRoleService.addToDidDoc(this.appPublishRole).subscribe({
+      next: () => {
+        this.appPublishRole.setIsSyncedOffChain(true).setIsSyncedOnChain(true);
+        this.updated.emit();
+      },
+    });
+  }
+}

--- a/src/app/shared/services/publish-role/publish-role.service.ts
+++ b/src/app/shared/services/publish-role/publish-role.service.ts
@@ -10,9 +10,11 @@ import { CancelButton } from '../../../layout/loading/loading.component';
 import { LoadingService } from '../loading.service';
 import { SwitchboardToastrService } from '../switchboard-toastr.service';
 import { catchError, finalize, map, switchMap } from 'rxjs/operators';
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { ClaimsFacadeService } from '../claims-facade/claims-facade.service';
 import { RegistrationTypes } from 'iam-client-lib';
+import { Store } from '@ngrx/store';
+import { UserClaimActions } from '@state';
 
 @Injectable({
   providedIn: 'root',
@@ -22,16 +24,11 @@ export class PublishRoleService {
     private dialog: MatDialog,
     private loadingService: LoadingService,
     private toastr: SwitchboardToastrService,
-    private claimsFacade: ClaimsFacadeService
+    private claimsFacade: ClaimsFacadeService,
+    private store: Store
   ) {}
 
-  addToDidDoc(element: {
-    issuedToken: string;
-    registrationTypes: RegistrationTypes[];
-    claimType: string;
-    claimTypeVersion: string;
-    subject?: string;
-  }) {
+  addToDidDoc(element: EnrolmentClaim) {
     return this.openConfirmationDialog({
       header: 'Publish credential to my DID document',
       svgIcon: 'sync-did-icon',
@@ -47,20 +44,6 @@ export class PublishRoleService {
       message:
         'It is necessary to register your role on-chain in order to make it available to verifying smart contracts. However, please note that this will make your role data permanently public.',
     }).pipe(switchMap(() => this.syncToClaimManager(element)));
-  }
-
-  async checkForNotSyncedOnChain(item) {
-    if (item.registrationTypes.includes(RegistrationTypes.OnChain)) {
-      return {
-        ...item,
-        notSyncedOnChain: !(await this.claimsFacade.hasOnChainRole(
-          item.claimType,
-          parseInt(item.claimTypeVersion.toString(), 10),
-          item.subject
-        )),
-      };
-    }
-    return item;
   }
 
   private openConfirmationDialog(data: {
@@ -83,56 +66,43 @@ export class PublishRoleService {
       .pipe(truthy());
   }
 
-  private syncClaimToDidDoc(element: {
-    issuedToken: string;
-    registrationTypes: RegistrationTypes[];
-    claimType: string;
-    claimTypeVersion: string;
-    subject?: string;
-  }) {
+  private syncClaimToDidDoc(element: EnrolmentClaim) {
     this.loadingService.show(
       'Please confirm this transaction in your connected wallet.',
       CancelButton.ENABLED
     );
-    return from(this.checkForNotSyncedOnChain(element)).pipe(
-      map((response) => {
-        const { notSyncedOnChain } = response;
-        // If the element is alreadypublish synced on chain, only off-chain registration is needed:
-        const registrationTypes = notSyncedOnChain
-          ? element.registrationTypes
-          : [RegistrationTypes.OffChain];
-        return registrationTypes;
-      }),
-      switchMap((regTypes: RegistrationTypes[]) => {
-        return this.claimsFacade
-          .publishPublicClaim({
-            registrationTypes: regTypes,
-            claim: {
-              token: element.issuedToken,
-              claimType: element.claimType,
-            },
-          })
-          .pipe(
-            map((retVal) => {
-              if (retVal) {
-                this.toastr.success('Action is successful.', 'Publish');
-              } else {
-                this.toastr.warning(
-                  'Unable to proceed with this action. Please contact system administrator.',
-                  'Publish'
-                );
-              }
-              return Boolean(retVal);
-            }),
-            catchError((err) => {
-              console.error(err);
-              this.toastr.error(err?.message, 'Sync to DID Document');
-              return of(err);
-            }),
-            finalize(() => this.loadingService.hide())
-          );
+    const registrationTypes = element.isSyncedOnChain
+      ? [RegistrationTypes.OffChain]
+      : element.registrationTypes;
+
+    return this.claimsFacade
+      .publishPublicClaim({
+        registrationTypes: registrationTypes,
+        claim: {
+          token: element.issuedToken,
+          claimType: element.claimType,
+        },
       })
-    );
+      .pipe(
+        map((retVal) => {
+          if (retVal) {
+            this.toastr.success('Action is successful.', 'Publish');
+            this.store.dispatch(UserClaimActions.loadUserClaims());
+          } else {
+            this.toastr.warning(
+              'Unable to proceed with this action. Please contact system administrator.',
+              'Publish'
+            );
+          }
+          return Boolean(retVal);
+        }),
+        catchError((err) => {
+          console.error(err);
+          this.toastr.error(err?.message, 'Sync to DID Document');
+          return of(err);
+        }),
+        finalize(() => this.loadingService.hide())
+      );
   }
 
   private syncToClaimManager(element) {


### PR DESCRIPTION
PR adds fix that hides `Publish` button after successful adding claim to did.
Also add proper check for asset enrolment if should display `Publish` button on the list of actions.
Additionally there is small refactor (e.g. removed not needed methods) + additional unit tests.
