### PR TITLE
fix: role type form alert

### DIFF
--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -268,7 +268,9 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
 
       this.displayAlert(
         'Request to enrol as ' +
-          this.roleTypeForm.value.roleType.toUpperCase() +
+          (
+            this.roleTypeForm.value.roleType as unknown as { name: string }
+          ).name.toUpperCase() +
           ' is submitted for review and approval.',
         'success'
       );

--- a/src/app/routes/registration/request-claim/request-claim.component.ts
+++ b/src/app/routes/registration/request-claim/request-claim.component.ts
@@ -266,6 +266,7 @@ export class RequestClaimComponent implements OnInit, SubjectElements {
         registrationTypes: enrolForm.registrationTypes,
       });
 
+      // TODO: Improve form field type from string to object
       this.displayAlert(
         'Request to enrol as ' +
           (


### PR DESCRIPTION
Typescript suggests `roleType` form field is a string, but seems to be an object, so applying the `toUpperCase()` method is causing an error. I just forced the type cast, but we should check the Form construction is correct for this field. I avoided that to prevent unexpected errors since I don't have that much context of the codebase.